### PR TITLE
Adds a UI animation when the WarningView is dismissed

### DIFF
--- a/phoenix-ios/phoenix-ios/views/RestoreWalletView.swift
+++ b/phoenix-ios/phoenix-ios/views/RestoreWalletView.swift
@@ -17,17 +17,16 @@ struct RestoreWalletView: MVIView {
                 .navigationBarTitle("Restore my wallet", displayMode: .inline)
     }
 
-    func view(model: RestoreWallet.Model, intent: @escaping IntentReceiver) -> some View {
-        return Group {
-            if let _ = model as? RestoreWallet.ModelWarning {
-                WarningView(intent: intent)
-                .zIndex(1)
-                .transition(.move(edge: .bottom))
-                .animation(.default)
-				} else {
-                RestoreView(model: model, intent: intent)
-                .zIndex(0)
-            }
+    @ViewBuilder func view(model: RestoreWallet.Model, intent: @escaping IntentReceiver) -> some View {
+        
+        if let _ = model as? RestoreWallet.ModelWarning {
+            WarningView(intent: intent)
+            .zIndex(1)
+            .transition(.move(edge: .bottom))
+            .animation(.default)
+        } else {
+            RestoreView(model: model, intent: intent)
+            .zIndex(0)
         }
     }
 


### PR DESCRIPTION
When the WarningView is dismissed, it now animates away by sliding off the screen downwards.

**Why**:
Previously the WarningView simply disappeared when the user tapped the "Next" button. But this felt rather un-Apple-like. Now it animates away. We can change the animation style, of course. But these changes are needed to enable animations.

**Details**:
The big change that was needed was to move away from using `AnyView`. From the Apple docs:

> Whenever the type of view used with an AnyView changes, the old hierarchy is destroyed and a new hierarchy is created for the new type.

The use of AnyView was preventing any kind of transition animation, since it was breaking the internal diffing architecture in SwiftUI.