### PR TITLE
Fixing blurry images, and improving english text

### DIFF
--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_arrow_back.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_arrow_back.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_arrow_next.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_arrow_next.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "ic_arrow_next.pdf",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {
@@ -19,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_bullet.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_bullet.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_check.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_check.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "ic_check.pdf",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {
@@ -19,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_check_circle.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_check_circle.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "ic_check_circle.pdf",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {
@@ -19,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_connection_lost.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_connection_lost.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_cross.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_cross.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_edit.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_edit.imageset/Contents.json
@@ -2,20 +2,14 @@
   "images" : [
     {
       "filename" : "ic_edit.pdf",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_fire.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_fire.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "ic_fire.pdf",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {
@@ -19,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_payment_success_static.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_payment_success_static.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_receive.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_receive.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_restore.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_restore.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "ic_restore.pdf",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {
@@ -19,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_scan.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_scan.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/Assets.xcassets/ic_settings.imageset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Assets.xcassets/ic_settings.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/phoenix-ios/phoenix-ios/views/TransactionView.swift
+++ b/phoenix-ios/phoenix-ios/views/TransactionView.swift
@@ -63,7 +63,7 @@ struct TransactionView : View {
                         +
                         Text("FAILED")
                                 .font(Font.title2.bold())
-                        Text("NO FUND HAS BEEN SENT")
+                        Text("NO FUNDS HAVE BEEN SENT")
                                 .font(Font.title2)
                     }
                             .padding()
@@ -89,7 +89,13 @@ struct TransactionView : View {
 
 class TransactionView_Previews : PreviewProvider {
     static var previews: some View {
-        TransactionView(transaction: mockSpendFailedTransaction, close: {})
+        TransactionView(
+			transaction: mockPendingTransaction,
+		//	transaction: mockSpendTransaction,
+		//	transaction: mockSpendFailedTransaction,
+		//	transaction: mockReceiveTransaction,
+			close: {}
+		)
     }
 
     #if DEBUG


### PR DESCRIPTION
I noticed a few blurry images in the app:
![Screen Shot 2020-10-26 at 11 16 03 AM](https://user-images.githubusercontent.com/304604/97467222-5a507b00-191a-11eb-8ba3-ec6655ca16f6.png)
We already have vector images, so this shouldn't be happening. The solution is to enable the "Preserve vector data" option within the "Assets.xcassets" catalog. You would think this wouldn't be needed, but alas...
<img width="464" alt="Screen Shot 2020-10-28 at 12 33 53 PM" src="https://user-images.githubusercontent.com/304604/97467716-dba80d80-191a-11eb-9692-7d0f37aaac04.png">
**Note**: This commit also improves the text: "no fund has been sent" => "no funds have been sent"