### PR TITLE
Support for both ios platforms (simulator & phone).

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -429,7 +429,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\necho ./gradlew :phoenix-shared:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION} -PskipAndroid=true\n./gradlew :phoenix-shared:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION} -PskipAndroid=true\n";
+			shellScript = "cd \"$SRCROOT/..\"\necho ./gradlew :phoenix-shared:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION} -PXCODE_PLATFORM_NAME=${PLATFORM_NAME} -PskipAndroid=true\n./gradlew :phoenix-shared:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION} -PXCODE_PLATFORM_NAME=${PLATFORM_NAME} -PskipAndroid=true\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
By default, compiles for iosX64.
However, XCode sets the `XCODE_PLATFORM_NAME` project property that, if set to `iphoneos` will build for iosArm64 instead.

Note that, when switching from a simulator to phone or back, XCode may refuse to start compilation on the ground that the existing framework isn't built for the correct platform. When that happens, you need to delete the `phoenix-shared/build/xcode-frameworks` directory, and XCode should allow the build to run.