### PR TITLE
Xcode fix: "existing framework isn't built for the correct platform"

### DIFF
--- a/phoenix-ios/phoenix-ios-framework/Info.plist
+++ b/phoenix-ios/phoenix-ios-framework/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -40,11 +40,12 @@
 		C8D7ABC95B979B59AF5A7CA7 /* InitializationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D7A209301A31C14A982ECD /* InitializationView.swift */; };
 		C8D7AFF5BC5754DBBEEB2688 /* ElectrumConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D7A1F8A123C59199C182C2 /* ElectrumConfigurationView.swift */; };
 		DC8107D3255F1FC1002084A3 /* RecoverySeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8107D2255F1FC1002084A3 /* RecoverySeedView.swift */; };
-		DCC8B1B92502BAE2006B6227 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DCC8B1B82502BAE1006B6227 /* Colors.xcassets */; };
-		DCF75B112559D97D009F16EB /* stylesheet.css in Resources */ = {isa = PBXBuildFile; fileRef = DCF75B0F2559D97D009F16EB /* stylesheet.css */; };
-		DCF75B142559D999009F16EB /* about.html in Resources */ = {isa = PBXBuildFile; fileRef = DCF75B162559D999009F16EB /* about.html */; };
-		F43B86AB24A49FA7004C1291 /* PhoenixShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F43B86AA24A49FA7004C1291 /* PhoenixShared.framework */; };
-		F43B86AC24A49FA7004C1291 /* PhoenixShared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F43B86AA24A49FA7004C1291 /* PhoenixShared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DC67654525655CA0004D4263 /* about.html in Resources */ = {isa = PBXBuildFile; fileRef = DC67654225655CA0004D4263 /* about.html */; };
+		DC67654625655CA0004D4263 /* stylesheet.css in Resources */ = {isa = PBXBuildFile; fileRef = DC67654425655CA0004D4263 /* stylesheet.css */; };
+		DC67654E25655D93004D4263 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC67654D25655D93004D4263 /* Colors.xcassets */; };
+		DCB0DB8A255AE42F005B29C8 /* PhoenixShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCB0DB83255AE42F005B29C8 /* PhoenixShared.framework */; };
+		DCB0DBB1255AEE22005B29C8 /* PhoenixShared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCB0DB83255AE42F005B29C8 /* PhoenixShared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DCC8B1B92502BAE2006B6227 /* (null) in Resources */ = {isa = PBXBuildFile; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +63,13 @@
 			remoteGlobalIDString = 7555FF7A242A565900829871;
 			remoteInfo = "phoenix-ios";
 		};
+		DCB0DBAF255AEE0E005B29C8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7555FF73242A565900829871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCB0DB82255AE42F005B29C8;
+			remoteInfo = "phoenix-ios-framework";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -71,7 +79,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F43B86AC24A49FA7004C1291 /* PhoenixShared.framework in Embed Frameworks */,
+				DCB0DBB1255AEE22005B29C8 /* PhoenixShared.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -118,10 +126,10 @@
 		C8D7A986A61CCD64FA661B88 /* DisplayConfigurationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayConfigurationView.swift; sourceTree = "<group>"; };
 		C8D7AFF1A7C09789C6CF2D06 /* ConfigurationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationView.swift; sourceTree = "<group>"; };
 		DC8107D2255F1FC1002084A3 /* RecoverySeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverySeedView.swift; sourceTree = "<group>"; };
-		DCC8B1B82502BAE1006B6227 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
-		DCF75B0F2559D97D009F16EB /* stylesheet.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = stylesheet.css; sourceTree = "<group>"; };
-		DCF75B152559D999009F16EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = Base; path = Base.lproj/about.html; sourceTree = "<group>"; };
-		F43B86AA24A49FA7004C1291 /* PhoenixShared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PhoenixShared.framework; path = "../phoenix-shared/build/xcode-frameworks/PhoenixShared.framework"; sourceTree = "<group>"; };
+		DC67654325655CA0004D4263 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = Base; path = Base.lproj/about.html; sourceTree = "<group>"; };
+		DC67654425655CA0004D4263 /* stylesheet.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = stylesheet.css; sourceTree = "<group>"; };
+		DC67654D25655D93004D4263 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		DCB0DB83255AE42F005B29C8 /* PhoenixShared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhoenixShared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,7 +137,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F43B86AB24A49FA7004C1291 /* PhoenixShared.framework in Frameworks */,
+				DCB0DB8A255AE42F005B29C8 /* PhoenixShared.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -141,6 +149,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		7555FF99242A565B00829871 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCB0DB80255AE42F005B29C8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -203,8 +218,8 @@
 				7555FF7D242A565900829871 /* phoenix-ios */,
 				7555FF94242A565B00829871 /* phoenix-iosTests */,
 				7555FF9F242A565B00829871 /* phoenix-iosUITests */,
+				DCB0DB84255AE42F005B29C8 /* phoenix-ios-framework */,
 				7555FF7C242A565900829871 /* Products */,
-				7555FFB0242A642200829871 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -214,6 +229,7 @@
 				7555FF7B242A565900829871 /* Phoenix.app */,
 				7555FF91242A565B00829871 /* phoenix-iosTests.xctest */,
 				7555FF9C242A565B00829871 /* phoenix-iosUITests.xctest */,
+				DCB0DB83255AE42F005B29C8 /* PhoenixShared.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -224,8 +240,8 @@
 				7555FF7E242A565900829871 /* PhoenixApplicationDelegate.swift */,
 				7555FF80242A565900829871 /* SceneDelegate.swift */,
 				7555FF82242A565900829871 /* ContentView.swift */,
-				DCC8B1B82502BAE1006B6227 /* Colors.xcassets */,
 				7555FF84242A565B00829871 /* Assets.xcassets */,
+				DC67654D25655D93004D4263 /* Colors.xcassets */,
 				7555FF89242A565B00829871 /* LaunchScreen.storyboard */,
 				7555FF8C242A565B00829871 /* Info.plist */,
 				7555FF86242A565B00829871 /* Preview Content */,
@@ -264,18 +280,10 @@
 			path = "phoenix-iosUITests";
 			sourceTree = "<group>";
 		};
-		7555FFB0242A642200829871 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				F43B86AA24A49FA7004C1291 /* PhoenixShared.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		C8D7A7335040D755924F8FFC /* configuration */ = {
 			isa = PBXGroup;
 			children = (
-				DCF75B0D2559D97D009F16EB /* about */,
+				DC67654125655CA0004D4263 /* about */,
 				C8D7AFF1A7C09789C6CF2D06 /* ConfigurationView.swift */,
 				C8D7A2327BC90150A3E1493D /* AboutView.swift */,
 				C8D7A986A61CCD64FA661B88 /* DisplayConfigurationView.swift */,
@@ -286,23 +294,39 @@
 			path = configuration;
 			sourceTree = "<group>";
 		};
-		DCF75B0D2559D97D009F16EB /* about */ = {
+		DC67654125655CA0004D4263 /* about */ = {
 			isa = PBXGroup;
 			children = (
-				DCF75B162559D999009F16EB /* about.html */,
-				DCF75B0F2559D97D009F16EB /* stylesheet.css */,
+				DC67654225655CA0004D4263 /* about.html */,
+				DC67654425655CA0004D4263 /* stylesheet.css */,
 			);
 			path = about;
 			sourceTree = "<group>";
 		};
+		DCB0DB84255AE42F005B29C8 /* phoenix-ios-framework */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "phoenix-ios-framework";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		DCB0DB7E255AE42F005B29C8 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		7555FF7A242A565900829871 /* phoenix-ios */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "phoenix-ios" */;
 			buildPhases = (
-				7555FFB5242A651A00829871 /* ShellScript */,
 				7555FF77242A565900829871 /* Sources */,
 				7555FF78242A565900829871 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
@@ -311,6 +335,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DCB0DBB0255AEE0E005B29C8 /* PBXTargetDependency */,
 			);
 			name = "phoenix-ios";
 			productName = "phoenix-ios";
@@ -353,6 +378,26 @@
 			productReference = 7555FF9C242A565B00829871 /* phoenix-iosUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		DCB0DB82255AE42F005B29C8 /* phoenix-ios-framework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DCB0DB8C255AE42F005B29C8 /* Build configuration list for PBXNativeTarget "phoenix-ios-framework" */;
+			buildPhases = (
+				DCB0DB95255AE43E005B29C8 /* ShellScript */,
+				DCB0DB7E255AE42F005B29C8 /* Headers */,
+				DCB0DB7F255AE42F005B29C8 /* Sources */,
+				DCB0DB80255AE42F005B29C8 /* Frameworks */,
+				DCB0DB81255AE42F005B29C8 /* Resources */,
+				DCB0DB9F255AE6F1005B29C8 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "phoenix-ios-framework";
+			productName = "phoenix-ios-framework";
+			productReference = DCB0DB83255AE42F005B29C8 /* PhoenixShared.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -374,6 +419,9 @@
 						CreatedOnToolsVersion = 11.3.1;
 						TestTargetID = 7555FF7A242A565900829871;
 					};
+					DCB0DB82255AE42F005B29C8 = {
+						CreatedOnToolsVersion = 12.1;
+					};
 				};
 			};
 			buildConfigurationList = 7555FF76242A565900829871 /* Build configuration list for PBXProject "phoenix-ios" */;
@@ -389,6 +437,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				DCB0DB82255AE42F005B29C8 /* phoenix-ios-framework */,
 				7555FF7A242A565900829871 /* phoenix-ios */,
 				7555FF90242A565B00829871 /* phoenix-iosTests */,
 				7555FF9B242A565B00829871 /* phoenix-iosUITests */,
@@ -402,11 +451,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				7555FF8B242A565B00829871 /* LaunchScreen.storyboard in Resources */,
-				DCC8B1B92502BAE2006B6227 /* Colors.xcassets in Resources */,
+				DCC8B1B92502BAE2006B6227 /* (null) in Resources */,
 				7555FF88242A565B00829871 /* Preview Assets.xcassets in Resources */,
-				DCF75B142559D999009F16EB /* about.html in Resources */,
+				DC67654525655CA0004D4263 /* about.html in Resources */,
 				7555FF85242A565B00829871 /* Assets.xcassets in Resources */,
-				DCF75B112559D97D009F16EB /* stylesheet.css in Resources */,
+				DC67654625655CA0004D4263 /* stylesheet.css in Resources */,
+				DC67654E25655D93004D4263 /* Colors.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -424,10 +474,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DCB0DB81255AE42F005B29C8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		7555FFB5242A651A00829871 /* ShellScript */ = {
+		DCB0DB95255AE43E005B29C8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -443,6 +500,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "cd \"$SRCROOT/..\"\necho ./gradlew :phoenix-shared:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION} -PXCODE_PLATFORM_NAME=${PLATFORM_NAME} -PskipAndroid=true\n./gradlew :phoenix-shared:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION} -PXCODE_PLATFORM_NAME=${PLATFORM_NAME} -PskipAndroid=true\n";
+		};
+		DCB0DB9F255AE6F1005B29C8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "SrcFrmk=\"$SRCROOT/../phoenix-shared/build/xcode-frameworks/PhoenixShared.framework\"\necho \"SrcFrmk = $SrcFrmk\"\n\nDstFrmk=\"$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME\"\necho \"DstFrmk = $DstFrmk\"\n\necho \"cp -R $SrcFrmk/ $DstFrmk/\"\ncp -R \"$SrcFrmk/\" \"$DstFrmk/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -498,6 +572,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DCB0DB7F255AE42F005B29C8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -511,6 +592,11 @@
 			target = 7555FF7A242A565900829871 /* phoenix-ios */;
 			targetProxy = 7555FF9D242A565B00829871 /* PBXContainerItemProxy */;
 		};
+		DCB0DBB0255AEE0E005B29C8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCB0DB82255AE42F005B29C8 /* phoenix-ios-framework */;
+			targetProxy = DCB0DBAF255AEE0E005B29C8 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -522,10 +608,10 @@
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
-		DCF75B162559D999009F16EB /* about.html */ = {
+		DC67654225655CA0004D4263 /* about.html */ = {
 			isa = PBXVariantGroup;
 			children = (
-				DCF75B152559D999009F16EB /* Base */,
+				DC67654325655CA0004D4263 /* Base */,
 			);
 			name = about.html;
 			sourceTree = "<group>";
@@ -653,7 +739,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"phoenix-ios/Preview Content\"";
-				DEVELOPMENT_TEAM = 8U7RQ73AR9;
+				DEVELOPMENT_TEAM = XD77LN4376;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../phoenix-shared/build/xcode-frameworks";
 				INFOPLIST_FILE = "phoenix-ios/Info.plist";
@@ -675,7 +761,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"phoenix-ios/Preview Content\"";
-				DEVELOPMENT_TEAM = 8U7RQ73AR9;
+				DEVELOPMENT_TEAM = XD77LN4376;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../phoenix-shared/build/xcode-frameworks";
 				INFOPLIST_FILE = "phoenix-ios/Info.plist";
@@ -771,6 +857,66 @@
 			};
 			name = Release;
 		};
+		DCB0DB8D255AE42F005B29C8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = XD77LN4376;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "phoenix-ios-framework/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "fr.acinq.phoenix-ios-framework";
+				PRODUCT_NAME = PhoenixShared;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		DCB0DB8E255AE42F005B29C8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = XD77LN4376;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "phoenix-ios-framework/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "fr.acinq.phoenix-ios-framework";
+				PRODUCT_NAME = PhoenixShared;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -806,6 +952,15 @@
 			buildConfigurations = (
 				7555FFAC242A565B00829871 /* Debug */,
 				7555FFAD242A565B00829871 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DCB0DB8C255AE42F005B29C8 /* Build configuration list for PBXNativeTarget "phoenix-ios-framework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCB0DB8D255AE42F005B29C8 /* Debug */,
+				DCB0DB8E255AE42F005B29C8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
This is a continuation of the work from pull #32. Recall we had the following problem:

> when switching from a simulator to phone or back, XCode may refuse to start compilation on the ground that the existing framework isn't built for the correct platform. When that happens, you need to delete the phoenix-shared/build/xcode-frameworks directory, and XCode should allow the build to run.

Here's what we had before:

![Screen Shot 2020-11-18 at 8 57 30 AM](https://user-images.githubusercontent.com/304604/99541807-462ef500-297f-11eb-8f6b-91b4c29eedb2.png)
![Screen Shot 2020-11-18 at 8 57 42 AM](https://user-images.githubusercontent.com/304604/99541823-4cbd6c80-297f-11eb-9fe6-9238c89ecc35.png)

The problem was that Xcode would check the architecture of the items in the "Embed frameworks" list BEFORE running the script (standard build process). And, of course, it would detect a different architecture (x86 vs arm64), and throw an error. I don't know if Apple considers this a bug... but I do. The "Embed frameworks" task clearly comes after the "Run script" task. But whatever... we can work around it.

Here's what we have now:

![Screen Shot 2020-11-18 at 8 57 01 AM](https://user-images.githubusercontent.com/304604/99542270-dd944800-297f-11eb-9e54-8b9b67cae838.png)
![Screen Shot 2020-11-18 at 8 56 15 AM](https://user-images.githubusercontent.com/304604/99542285-e127cf00-297f-11eb-899e-84d0e85e2f87.png)
![Screen Shot 2020-11-18 at 8 56 48 AM](https://user-images.githubusercontent.com/304604/99542295-e38a2900-297f-11eb-90e5-a023a69eb406.png)

And now we can switch back and forth, between building for simulator and device, and not run into that problem !

One last note:

![Screen Shot 2020-11-18 at 8 58 30 AM](https://user-images.githubusercontent.com/304604/99542577-3c59c180-2980-11eb-8d37-63dd21515a30.png)

In order to run this you'll need to be part of the ACINQ team. Dominique has already added you (Romain & Salomon). But Xcode may not know this yet:

- go to Xcode / Preferences / Accounts
- check to see if ACINQ appears as a Team for your Apple ID
- if not, then remove your Apple ID from Xcode, and then re-add it (this will force Xcode to refresh your list of Teams)
