### PR TITLE
Bug fix: DisplayConfigurationView now supports dark mode

### DIFF
--- a/phoenix-ios/phoenix-ios/views/configuration/DisplayConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/DisplayConfigurationView.swift
@@ -3,52 +3,58 @@ import PhoenixShared
 
 struct DisplayConfigurationView: View {
 
-    var body: some View {
-        MVIView({ $0.displayConfiguration() }) { model, postIntent in
-            Form {
-                Section {
-                    Picker(
-                            selection: Binding(
-                                    get: { model.fiatCurrency },
-                                    set: { postIntent(DisplayConfiguration.IntentUpdateFiatCurrency(fiatCurrency: $0)) }
-                            ), label: Text("Fiat currency")) {
-                        ForEach(0..<FiatCurrency.default().values.count) {
-                            let fiatCurrency = FiatCurrency.default().values[$0]
-                            Text(fiatCurrency.label).tag(fiatCurrency)
-                        }
-                    }
+	var body: some View {
+		MVIView({ $0.displayConfiguration() }) { model, postIntent in
+			Form {
+				Section {
+					Picker(
+						selection: Binding(
+							get: { model.fiatCurrency },
+							set: {
+								postIntent(DisplayConfiguration.IntentUpdateFiatCurrency(fiatCurrency: $0))
+							}
+						), label: Text("Fiat currency")
+					) {
+						ForEach(0 ..< FiatCurrency.default().values.count) {
+							let fiatCurrency = FiatCurrency.default().values[$0]
+							Text(fiatCurrency.label).tag(fiatCurrency)
+						}
+					}
+					
+					Picker(
+						selection: Binding(
+							get: { model.bitcoinUnit },
+							set: {
+								postIntent(DisplayConfiguration.IntentUpdateBitcoinUnit(bitcoinUnit: $0))
+							}
+						), label: Text("Bitcoin unit")
+					) {
+						ForEach(0 ..< BitcoinUnit.default().values.count) {
+							let unit = BitcoinUnit.default().values[$0]
+							Text(unit.label).tag(unit)
+						}
+					}
                 }
 
-                Section {
-                    Picker(
-                            selection: Binding(
-                                    get: { model.bitcoinUnit },
-                                    set: { postIntent(DisplayConfiguration.IntentUpdateBitcoinUnit(bitcoinUnit: $0)) }
-                            ), label: Text("Bitcoin unit")) {
-                        ForEach(0..<BitcoinUnit.default().values.count) {
-                            let unit = BitcoinUnit.default().values[$0]
-                            Text(unit.label).tag(unit)
-                        }
-                    }
-                }
-
-                Section {
-                    Picker(
-                            selection: Binding(
-                                    get: { model.appTheme },
-                                    set: { postIntent(DisplayConfiguration.IntentUpdateAppTheme(appTheme: $0)) }
-                            ), label: Text("application theme")) {
-                        ForEach(0..<AppTheme.default().values.count) {
-                            let theme = AppTheme.default().values[$0]
-                            Text(theme.label).tag(theme)
-                        }
-                    }.pickerStyle(SegmentedPickerStyle())
-                }
-            }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color.appBackground)
-                    .edgesIgnoringSafeArea(.bottom)
-                    .navigationBarTitle("Display options", displayMode: .inline)
+				Section {
+					Picker(
+						selection: Binding(
+							get: { model.appTheme },
+							set: {
+								postIntent(DisplayConfiguration.IntentUpdateAppTheme(appTheme: $0))
+							}
+						), label: Text("application theme")
+					) {
+						ForEach(0..<AppTheme.default().values.count) {
+							let theme = AppTheme.default().values[$0]
+							Text(theme.label).tag(theme)
+						}
+					}.pickerStyle(SegmentedPickerStyle())
+				}
+			}
+			.frame(maxWidth: .infinity, maxHeight: .infinity)
+			.edgesIgnoringSafeArea(.bottom)
+			.navigationBarTitle("Display options", displayMode: .inline)
 
             Spacer()
         }
@@ -56,12 +62,17 @@ struct DisplayConfigurationView: View {
 }
 
 class DisplayConfigurationView_Previews: PreviewProvider {
-    static let mockModel = DisplayConfiguration.Model(fiatCurrency: .usd, bitcoinUnit: .satoshi, appTheme: .system)
 
-    static var previews: some View {
-        mockView(DisplayConfigurationView())
-                .previewDevice("iPhone 11")
-    }
+	static let mockModel = DisplayConfiguration.Model(
+		fiatCurrency: .usd,
+		bitcoinUnit: .satoshi,
+		appTheme: .system
+	)
+
+	static var previews: some View {
+		mockView(DisplayConfigurationView())
+			.previewDevice("iPhone 11")
+	}
 
     #if DEBUG
     @objc class func injected() {


### PR DESCRIPTION
Before:
<img width="300" alt="Screen Shot 2020-11-16 at 10 38 46 AM" src="https://user-images.githubusercontent.com/304604/99546113-17ffe400-2984-11eb-9f60-9d354faecbe5.png">

After:
<img width="300" alt="Screen Shot 2020-11-16 at 10 39 43 AM" src="https://user-images.githubusercontent.com/304604/99546165-277f2d00-2984-11eb-818b-f9e4de665e74.png">

Side note: I think it would look cleaner if we only displayed the "short names" in this view: "USD" and "Satoshis"