### PR TITLE
Bug fixes for dark mode: ReceiveView

### DIFF
--- a/phoenix-ios/phoenix-ios/Colors.xcassets/accent.colorset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Colors.xcassets/accent.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "209",
+          "green" : "180",
+          "red" : "145"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "138",
+          "green" : "196",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/phoenix-ios/phoenix-ios/Colors.xcassets/buttonFill.colorset/Contents.json
+++ b/phoenix-ios/phoenix-ios/Colors.xcassets/buttonFill.colorset/Contents.json
@@ -1,0 +1,33 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "250",
+          "green" : "250",
+          "red" : "250"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "platform" : "ios",
+        "reference" : "systemFillColor"
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/phoenix-ios/phoenix-ios/colors.swift
+++ b/phoenix-ios/phoenix-ios/colors.swift
@@ -25,5 +25,8 @@ extension Color {
     static let appRed = Color("appRed")
     static let appGreen = Color("appGreen")
     static let appYellow = Color("appYellow")
+	
+	static let accent = Color("accent")
+	static let buttonFill = Color("buttonFill")
 
 }


### PR DESCRIPTION
Just some dark-mode fixes. **Before**:

![Screen Shot 2020-11-23 at 2 36 41 PM](https://user-images.githubusercontent.com/304604/100008507-8df8b680-2d9b-11eb-8883-5c46b3ee2eff.png)
<img width="300" alt="Screen Shot 2020-11-23 at 2 44 54 PM" src="https://user-images.githubusercontent.com/304604/100008516-8fc27a00-2d9b-11eb-89f8-c96710bf4703.png">

**After**:

<img width="300" alt="Screen Shot 2020-11-23 at 12 47 52 PM" src="https://user-images.githubusercontent.com/304604/100008582-a1a41d00-2d9b-11eb-9588-53986a8b69d7.png">
<img width="300" alt="Screen Shot 2020-11-23 at 12 48 06 PM" src="https://user-images.githubusercontent.com/304604/100008592-a4067700-2d9b-11eb-8483-b6df54109967.png">

Note: I added text fields that display the amount & description on the main screen. (In the screenshot above: "400 sat" & "Chocolate pudding cup") If there's nothing set, it says "any amount" or "no description". I think it's comforting to see after returning from the "modify" screen. I'm not sure how I feel about the text labels being there when one first enters this view.
