### PR TITLE
Rename variable: amountSat -> amountMsat

### DIFF
--- a/phoenix-ios/phoenix-ios/utils/mocks.swift
+++ b/phoenix-ios/phoenix-ios/utils/mocks.swift
@@ -8,7 +8,7 @@ import PhoenixShared
 
 let mockPendingTransaction = Transaction(
         id: "0",
-        amountSat: -1900,
+        amountMsat: -1900,
         desc: "1 Scala Chip Frappuccino",
         status: Transaction.Status.pending,
         timestamp: 0
@@ -22,7 +22,7 @@ let mockPendingTransaction = Transaction(
 
 let mockSpendTransaction = Transaction(
         id: "1",
-        amountSat: -1500,
+        amountMsat: -1500,
         desc: "1 Blockaccino",
         status: Transaction.Status.success,
         timestamp: 0
@@ -36,7 +36,7 @@ let mockSpendTransaction = Transaction(
 
 let mockReceiveTransaction = Transaction(
         id: "2",
-        amountSat: 125000,
+        amountMsat: 125000,
         desc: "On-Chain payment to 8b44f33a8c86f1fe0c18935df9db961ff5a6edb4ee49d3cee666458745d676fd",
         status: Transaction.Status.success,
         timestamp: 0
@@ -50,7 +50,7 @@ let mockReceiveTransaction = Transaction(
 
 let mockSpendFailedTransaction = Transaction(
         id: "3",
-        amountSat: -1700,
+        amountMsat: -1700,
         desc: "1 Espresso Coin Panna",
         status: Transaction.Status.failure,
         timestamp: 0

--- a/phoenix-ios/phoenix-ios/views/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/HomeView.swift
@@ -254,12 +254,8 @@ struct HomeView : View {
                 if transaction.status != .failure {
 					HStack(spacing: 0) {
 						
-						// transaction.amountSat is actually in msat !
-						// There is a pending PR that contains a fix for this bug.
-						// I'm going to try to get it merged independently of the PR soon.
-						//
-						let amount = Utils.format(currencyPrefs, msat: transaction.amountSat)
-						let isNegative = transaction.amountSat < 0
+						let amount = Utils.format(currencyPrefs, msat: transaction.amountMsat)
+						let isNegative = transaction.amountMsat < 0
 						
 						Text(isNegative ? "" : "+")
 							.foregroundColor(isNegative ? .appRed : .appGreen)

--- a/phoenix-ios/phoenix-ios/views/ScanView.swift
+++ b/phoenix-ios/phoenix-ios/views/ScanView.swift
@@ -115,8 +115,8 @@ struct ScanView: View {
         init(model: Scan.ModelValidate, postIntent: @escaping (Scan.Intent) -> Void) {
             self.model = model
 
-            if let amountSat = model.amountSat {
-                self._amount = State(initialValue: String(amountSat.int64Value))
+            if let amountMsat = model.amountMsat {
+                self._amount = State(initialValue: String(amountMsat.int64Value))
             } else {
                 self._amount = State(initialValue: "")
             }
@@ -253,7 +253,7 @@ class ScanView_Previews: PreviewProvider {
 
     static let mockModel = Scan.ModelValidate(
             request: "lntb15u1p0hxs84pp5662ywy9px43632le69s5am03m6h8uddgln9cx9l8v524v90ylmesdq4xysyymr0vd4kzcmrd9hx7cqp2xqrrss9qy9qsqsp5xr4khzu3xter2z7dldnl3eqggut200vzth6cj8ppmqvx29hzm30q0as63ks9zddk3l5vf46lmkersynge3fy9nywwn8z8ttfdpak5ka9dvcnfrq95e6s06jacnsdryq8l8mrjkrfyd3vxgyv4axljvplmwsqae7yl9",
-            amountSat: 1500,
+            amountMsat: 1500,
             requestDescription: "1 Blockaccino"
     )
 

--- a/phoenix-ios/phoenix-ios/views/TransactionView.swift
+++ b/phoenix-ios/phoenix-ios/views/TransactionView.swift
@@ -39,7 +39,7 @@ struct TransactionView : View {
                             .frame(width: 100, height: 100)
                             .foregroundColor(.appGreen)
                     VStack {
-                        Text(transaction.amountSat < 0 ? "SENT" : "RECEIVED")
+                        Text(transaction.amountMsat < 0 ? "SENT" : "RECEIVED")
                                 .font(Font.title2.bold())
                         Text(transaction.timestamp.formatDateMS().uppercased())
                                 .font(Font.title2)
@@ -73,11 +73,7 @@ struct TransactionView : View {
                 }
 
                 HStack(alignment: .bottom) {
-					// transaction.amountSat is actually in msat !
-					// There is a pending PR that contains a fix for this bug.
-					// I'm going to try to get it merged independently of the PR soon.
-					//
-					let amount = Utils.format(currencyPrefs, msat: transaction.amountSat)
+					let amount = Utils.format(currencyPrefs, msat: transaction.amountMsat)
 					
                     Text(amount.digits)
                         .font(.largeTitle)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppHistoryManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppHistoryManager.kt
@@ -55,7 +55,7 @@ class AppHistoryManager(private val appDb: DB, private val peer: Peer) : Corouti
                         appDb.put(
                             Transaction(
                                 id = it.request.paymentId.toString(),
-                                amountSat = -totalAmount.toLong(), // storing value in MilliSatoshi
+                                amountMsat = -totalAmount.toLong(),
                                 desc = it.request.details.paymentRequest.description ?: "",
                                 status = Transaction.Status.Pending,
                                 timestamp = currentTimestampMillis()
@@ -69,7 +69,7 @@ class AppHistoryManager(private val appDb: DB, private val peer: Peer) : Corouti
                         appDb.put(
                             Transaction(
                                 id = it.payment.id.toString(),
-                                amountSat = -totalAmount.toLong(), // storing value in MilliSatoshi
+                                amountMsat = -totalAmount.toLong(),
                                 desc = when (val details = it.payment.details) {
                                     is OutgoingPayment.Details.Normal -> details.paymentRequest.description ?: ""
                                     is OutgoingPayment.Details.KeySend -> ""
@@ -84,7 +84,7 @@ class AppHistoryManager(private val appDb: DB, private val peer: Peer) : Corouti
                         appDb.put(
                             Transaction(
                                 id = it.request.paymentId.toString(),
-                                amountSat = -it.request.amount.msat, // storing value in MilliSatoshi
+                                amountMsat = -it.request.amount.msat,
                                 desc = it.reason.message(),
                                 status = Transaction.Status.Failure,
                                 timestamp = currentTimestampMillis()

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppScanController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppScanController.kt
@@ -55,7 +55,7 @@ class AppScanController(loggerFactory: LoggerFactory, private val peer: Peer) : 
         model(
             Scan.Model.Validate(
                 request = request,
-                amountSat = paymentRequest.amount?.truncateToSatoshi()?.toLong(),
+                amountMsat = paymentRequest.amount?.toLong(),
                 requestDescription = paymentRequest.description
             )
         )

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/ScanController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/ScanController.kt
@@ -11,7 +11,7 @@ object Scan {
         object Ready: Model()
         object BadRequest: Model()
         data class RequestWithoutAmount(val request: String): Model()
-        data class Validate(val request: String, val amountSat: Long?, val requestDescription: String?): Model()
+        data class Validate(val request: String, val amountMsat: Long?, val requestDescription: String?): Model()
         object Sending: Model()
     }
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/Transaction.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/Transaction.kt
@@ -9,7 +9,7 @@ import org.kodein.db.model.orm.Metadata
 @Serializable
 data class Transaction(
     override val id: String,
-    val amountSat: Long,
+    val amountMsat: Long,
     val desc: String, // Swift does not support fields named description
     val status: Status,
     val timestamp: Long


### PR DESCRIPTION
Transaction amounts are stored in millisatoshi, but have been incorrectly named `amountSat`. This fixes the issue by renaming variable to `amountMsat`.

(cherry-picked from: @romainbsl , branch: feature/displayed-currency)