### PR TITLE
Connection daemon - remove confusing log

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConnectionsDaemon.kt
@@ -218,8 +218,6 @@ class AppConnectionsDaemon(
     private fun connectionLoop(name: String, statusStateFlow: StateFlow<Connection>, connect: () -> Unit) = launch {
         var retryDelay = RETRY_DELAY
         statusStateFlow.collect {
-            logger.debug { "New $name status $it" }
-
             if (it == Connection.CLOSED) {
                 logger.debug { "Wait for $retryDelay before retrying connection on $name" }
                 delay(retryDelay) ; retryDelay = increaseDelay(retryDelay)


### PR DESCRIPTION
We refactored the `Peer` connection handler in `eclair-kmp` (see https://github.com/ACINQ/eclair-kmp/pull/182).

I just removed the log that show the "new" state for `Peer` or `ElectrumClient` as it is not accurate.
Indeed, looking at the following logs we had before https://github.com/ACINQ/eclair-kmp/pull/182:

```
// Moving the app to the background

2021-01-25 09:59:01.860112+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] peerControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=1)
2021-01-25 09:59:01.860271+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] electrumControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=1)
2021-01-25 09:59:01.860382+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] httpApiControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=1)
2021-01-25 09:59:01.866004+0100 Phoenix[38188:3743604] [Peer] n:03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134 disconnecting channels
// Peer is closing here !!

// Moving the app to the foreground 42s later

2021-01-25 09:59:43.505727+0100 Phoenix[38188:3744673] [connection] nw_read_request_report [C22] Receive failed with error "Software caused connection abort"
2021-01-25 09:59:43.506029+0100 Phoenix[38188:3744673] [connection] nw_read_request_report [C23] Receive failed with error "Software caused connection abort"
2021-01-25 09:59:43.512700+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] peerControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=0)
2021-01-25 09:59:43.513049+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] electrumControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=0)
2021-01-25 09:59:43.513211+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] httpApiControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=0)
2021-01-25 09:59:43.514207+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] New Peer status CLOSED
// New connection state ?! not really.
```

Logs we would have after https://github.com/ACINQ/eclair-kmp/pull/182:

```
2021-01-25 09:59:01.860112+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] peerControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=1)
2021-01-25 09:59:01.860271+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] electrumControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=1)
2021-01-25 09:59:01.860382+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] httpApiControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=1)
2021-01-25 09:59:01.862974+0100 Phoenix[38188:3743604] [Peer] n:03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134 cose TCP slocket
2021-01-25 09:59:01.866004+0100 Phoenix[38188:3743604] [Peer] n:03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134 connection state changed: CLOSED

// More accurate log.

2021-01-25 09:59:01.866179+0100 Phoenix[38188:3743604] [Peer] n:03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134 disconnecting channels

2021-01-25 09:59:43.505727+0100 Phoenix[38188:3744673] [connection] nw_read_request_report [C22] Receive failed with error "Software caused connection abort"
2021-01-25 09:59:43.506029+0100 Phoenix[38188:3744673] [connection] nw_read_request_report [C23] Receive failed with error "Software caused connection abort"
2021-01-25 09:59:43.512700+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] peerControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=0)
2021-01-25 09:59:43.513049+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] electrumControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=0)
2021-01-25 09:59:43.513211+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] httpApiControlFlow = TrafficControl(networkIsAvailable=true, disconnectCount=0)
2021-01-25 09:59:43.514207+0100 Phoenix[38188:3743604] [AppConnectionsDaemon] New Peer status CLOSED

// This is not relevant, must be removed (by this PR)
```