### PR TITLE
First pass on Transaction screen improvements

### DIFF
--- a/phoenix-ios/phoenix-ios/views/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/HomeView.swift
@@ -91,6 +91,7 @@ struct HomeView : View {
 							payment: selectedPayment!,
 							close: { selectedPayment = nil }
 						)
+						.modifier(GlobalEnvironment()) // SwiftUI bug (prevent crash)
 					}
 				}
 
@@ -119,7 +120,7 @@ struct PaymentCell : View {
 
 	var body: some View {
 		HStack {
-			switch (payment.status()) {
+			switch payment.state() {
 			case .success:
 				Image("payment_holder_def_success")
 					.padding(4)
@@ -148,7 +149,7 @@ struct PaymentCell : View {
 			.frame(maxWidth: .infinity, alignment: .leading)
 			.padding([.leading, .trailing], 6)
 			
-			if payment.status() != .failure {
+			if payment.state() != .failure {
 				HStack(spacing: 0) {
 					
 					let amount = Utils.format(currencyPrefs, msat: payment.amountMsat())

--- a/phoenix-ios/phoenix-ios/views/ReceiveView.swift
+++ b/phoenix-ios/phoenix-ios/views/ReceiveView.swift
@@ -570,8 +570,7 @@ struct ReceiveView: AltMviView {
 			return
 		}
 		
-		let status = lastIncomingPayment.status()
-		if status == WalletPaymentStatus.success {
+		if lastIncomingPayment.state() == WalletPaymentState.success {
 			
 			if lastIncomingPayment.paymentHash.toHex() == model.paymentHash {
 				self.mode.wrappedValue.dismiss()

--- a/phoenix-ios/phoenix-ios/views/TransactionView.swift
+++ b/phoenix-ios/phoenix-ios/views/TransactionView.swift
@@ -1,5 +1,15 @@
 import SwiftUI
 import PhoenixShared
+import os.log
+
+#if DEBUG && false
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "TransactionView"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
 
 struct PaymentView : View {
 
@@ -11,6 +21,10 @@ struct PaymentView : View {
 	var body: some View {
 		
 		ZStack {
+			
+			main()
+			
+			// Close button in upper right-hand corner
 			VStack {
 				HStack {
 					Spacer()
@@ -25,124 +39,91 @@ struct PaymentView : View {
 				}
 				Spacer()
 			}
-
-			VStack {
-				switch (payment.status()) {
-				case .success:
-				//	Image(vector: "ic_payment_success_static") // looks pixelated
-					Image(systemName: "checkmark.circle")
-						.renderingMode(.template)
-						.resizable()
-						.aspectRatio(contentMode: .fit)
-						.frame(width: 100, height: 100)
-						.foregroundColor(.appGreen)
-					VStack {
-						Text(payment.amountMsat() < 0 ? "SENT" : "RECEIVED")
-							.font(Font.title2.bold())
-							.padding(.bottom, 2)
-						Text(payment.timestamp().formatDateMS())
-							.font(.subheadline)
-							.foregroundColor(.secondary)
-					}
-					.padding()
-					
-				case .pending:
-					Image("ic_send")
-						.renderingMode(.template)
-						.resizable()
-						.foregroundColor(Color(UIColor.systemGray))
-						.frame(width: 100, height: 100)
-					Text("PENDING")
+		}
+	}
+	
+	@ViewBuilder
+	func main() -> some View {
+		
+		VStack {
+			switch payment.state() {
+			case .success:
+				Image(systemName: "checkmark.circle")
+					.renderingMode(.template)
+					.resizable()
+					.aspectRatio(contentMode: .fit)
+					.frame(width: 100, height: 100)
+					.foregroundColor(.appGreen)
+				VStack {
+					Text(payment.amountMsat() < 0 ? "SENT" : "RECEIVED")
 						.font(Font.title2.bold())
-						.padding()
-					
-				case .failure:
-				//	Image(vector: "ic_cross") // looks pixelated
-					Image(systemName: "xmark.circle")
-						.renderingMode(.template)
-						.resizable()
-						.frame(width: 100, height: 100)
-						.foregroundColor(.appRed)
-					VStack {
-						Text("FAILED")
-							.font(Font.title2.bold())
-							.padding(.bottom, 2)
-                        
-						Text("NO FUNDS HAVE BEEN SENT")
-							.font(Font.title2.uppercaseSmallCaps())
-							.padding(.bottom, 6)
-						
-						Text(payment.timestamp().formatDateMS())
-							.font(Font.subheadline)
-							.foregroundColor(.secondary)
-						
-					}
-					.padding()
-					
-				default:
-					EmptyView()
-				}
-
-				HStack(alignment: .bottom) {
-					let amount = Utils.format(currencyPrefs, msat: payment.amountMsat(), hideMsats: false)
-					
-					Text(amount.digits)
-						.font(.largeTitle)
-						.onTapGesture { toggleCurrencyType() }
-					Text(amount.type)
-						.font(.title3)
-						.foregroundColor(.gray)
-						.padding(.bottom, 4)
-						.onTapGesture { toggleCurrencyType() }
+						.padding(.bottom, 2)
+					Text(payment.timestamp().formatDateMS())
+						.font(.subheadline)
+						.foregroundColor(.secondary)
 				}
 				.padding()
-				.background(
-					VStack {
-						Spacer()
-						Line().stroke(Color.appHorizon, style: StrokeStyle(lineWidth: 4, lineCap: .round))
-							.frame(height: 4)
-					}
-				)
-
-                VStack(alignment: .leading){
-                    HStack(alignment: .top) {
-                        let desc = payment.desc() ?? NSLocalizedString("No description", comment: "placeholder text")
-
-                        Text("Desc")
-                            .foregroundColor(.secondary)
-                        Text(desc)
-                            .contextMenu {
-                                Button(action: {
-                                    UIPasteboard.general.string = desc
-                                }) {
-                                    Text("Copy")
-                                }
-                            }
-                    }
-                    .padding([.leading, .trailing])
-
-                    let errorMessage = payment.errorMessage()
-                    if errorMessage != nil {
-                        HStack(alignment: .top) {
-                            Text("Error")
-                                .foregroundColor(.secondary)
-                            Text(errorMessage!)
-                                .contextMenu {
-                                    Button(action: {
-                                        UIPasteboard.general.string = errorMessage
-                                    }) {
-                                        Text("Copy")
-                                    }
-                                }
-                        }
-                        .padding(.top, 10)
-                        .padding([.leading, .trailing])
-                    }
+				
+			case .pending:
+				Image("ic_send")
+					.renderingMode(.template)
+					.resizable()
+					.foregroundColor(Color(UIColor.systemGray))
+					.frame(width: 100, height: 100)
+				Text("PENDING")
+					.font(Font.title2.bold())
+					.padding()
+				
+			case .failure:
+				Image(systemName: "xmark.circle")
+					.renderingMode(.template)
+					.resizable()
+					.frame(width: 100, height: 100)
+					.foregroundColor(.appRed)
+				VStack {
+					Text("FAILED")
+						.font(Font.title2.bold())
+						.padding(.bottom, 2)
+					
+					Text("NO FUNDS HAVE BEEN SENT")
+						.font(Font.title2.uppercaseSmallCaps())
+						.padding(.bottom, 6)
+					
+					Text(payment.timestamp().formatDateMS())
+						.font(Font.subheadline)
+						.foregroundColor(.secondary)
+					
 				}
-				.padding([.leading, .trailing])
+				.padding()
+				
+			default:
+				EmptyView()
 			}
+
+			HStack(alignment: .bottom) {
+				let amount = Utils.format(currencyPrefs, msat: payment.amountMsat(), hideMsats: false)
+
+				Text(amount.digits)
+					.font(.largeTitle)
+					.onTapGesture { toggleCurrencyType() }
+				Text(amount.type)
+					.font(.title3)
+					.foregroundColor(.gray)
+					.padding(.bottom, 4)
+					.onTapGesture { toggleCurrencyType() }
+			}
+			.padding()
+			.background(
+				VStack {
+					Spacer()
+					Line().stroke(Color.appHorizon, style: StrokeStyle(lineWidth: 4, lineCap: .round))
+						.frame(height: 4)
+				}
+			)
+			.padding(.bottom, 4)
+			
+			InfoGrid(payment: payment)
 		}
-		.frame(maxWidth: .infinity, maxHeight: .infinity)
 	}
 	
 	func toggleCurrencyType() -> Void {
@@ -150,29 +131,447 @@ struct PaymentView : View {
 	}
 }
 
-//class PaymentView_Previews : PreviewProvider {
+// Architecture Design:
+//
+// We want to display a list of key/value pairs:
+//
+//     Desc: Pizza reimbursement
+//     Fees: 2 sat
+//  Elapsed: 2.4 seconds
+//
+// Requirements:
+// 1. the elements must be vertically aligned
+//   - all keys have same trailing edge
+//   - all values have same leading edge
+// 2. the list (as a whole) must be horizontally centered
+//
+//       1,042 sat
+//       ---------
+// Desc: Party
+//
+//      ^ Wrong! List not horizontally centered!
+//
+//       1,042 sat
+//       ---------
+//      Desc: Party
+//
+//      ^ Correct!
+//
+// Ultimately, we need to:
+// - assign all keys the same width
+// - ensure the assigned width is the minimum possible width
+//
+// This was super easy with UIKit.
+// We could simply add constraints such that all keys are equal width.
+//
+// In SwiftUI, it's not that simple. But it's not that bad either.
+//
+// - we used InfoGrid_Column0 to measure the width of each key
+// - we use InfoGrid_Column0_MeasuredWidth to communicate the width
+//   up the hierarchy to the InfoGrid.
+// - InfoGrid_Column0_MeasuredWidth.reduce is used to find the max width
+// - InfoGrid assigns the maxWidth to each key frame
+//
+// Note that this occurs in 2 passes.
+// - In the first pass, InfoGrid.widthColumn0 is nil
+// - It then lays out all the elements, and they get measured
+// - The width is passed up the hierarchy via InfoGrid_Column0_MeasuredWidth preference
+// - This triggers InfoGrid.onPreferenceChange(InfoGrid_Column0_MeasuredWidth.self)
+// - Which triggers a second layout pass
+//
+struct InfoGrid: View {
 	
-//    static var previews: some View {
-//        PaymentView(payment: PhoenixShared.Mock.outgoingPending(), close: {})
-//			.preferredColorScheme(.dark)
-//			.environmentObject(CurrencyPrefs.mockEUR())
-//
-//        PaymentView(payment: PhoenixShared.Mock.outgoingSuccessful(), close: {})
-//			.preferredColorScheme(.dark)
-//			.environmentObject(CurrencyPrefs.mockEUR())
-//
-//        PaymentView(payment: PhoenixShared.Mock.outgoingFailed(), close: {})
-//			.preferredColorScheme(.dark)
-//			.environmentObject(CurrencyPrefs.mockEUR())
-//
-//        PaymentView(payment: PhoenixShared.Mock.incomingPaymentReceived(), close: {})
-//			.preferredColorScheme(.dark)
-//			.environmentObject(CurrencyPrefs.mockEUR())
-//	}
-//
-//	#if DEBUG
-//	@objc class func injected() {
-//		UIApplication.shared.windows.first?.rootViewController = UIHostingController(rootView: previews)
-//	}
-//	#endif
-//}
+	let payment: PhoenixShared.Eclair_kmpWalletPayment
+	
+	@State private var widthColumn0: CGFloat? = nil
+	
+	private let cappedWidthColumn0: CGFloat = 200
+	
+	private let verticalSpacingBetweenRows: CGFloat = 8
+	private let horizontalSpacingBetweenColumns: CGFloat = 8
+	
+	@Environment(\.openURL) var openURL
+	@EnvironmentObject var currencyPrefs: CurrencyPrefs
+	
+	var body: some View {
+		
+		VStack(
+			alignment : HorizontalAlignment.leading,
+			spacing   : verticalSpacingBetweenRows
+		) {
+			
+			if let pDescription = payment.paymentDescription() {
+				
+				HStack(
+					alignment : VerticalAlignment.top,
+					spacing   : horizontalSpacingBetweenColumns
+				) {
+					HStack(alignment: VerticalAlignment.top, spacing: 0) {
+						Spacer(minLength: 0) // => HorizontalAlignment.trailing
+						InfoGrid_Column0 {
+							Text("Desc")
+								.foregroundColor(.secondary)
+						}
+					}
+					.frame(width: widthColumn0)
+					
+					Text(pDescription)
+						.contextMenu {
+							Button(action: {
+								UIPasteboard.general.string = pDescription
+							}) {
+								Text("Copy")
+							}
+						}
+				}
+			} // </if let pDescription>
+			
+			if let pType = payment.paymentType() {
+				
+				HStack(
+					alignment : VerticalAlignment.top,
+					spacing   : horizontalSpacingBetweenColumns
+				) {
+					HStack(alignment: VerticalAlignment.top, spacing: 0) {
+						Spacer(minLength: 0) // => HorizontalAlignment.trailing
+						InfoGrid_Column0 {
+							Text("Type")
+								.foregroundColor(.secondary)
+						}
+					}
+					.frame(width: widthColumn0)
+					
+					VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+						
+						Text(pType.0)
+						+ Text(" (\(pType.1)")
+							.font(.subheadline)
+							.foregroundColor(.secondary)
+						
+						if let link = payment.paymentLink() {
+							Button {
+								openURL(link)
+							} label: {
+								Text("blockchain tx")
+							}
+						}
+					}
+				}
+			} // </if let pType>
+			
+			if let pFees = payment.paymentFees(currencyPrefs: currencyPrefs) {
+
+				HStack(
+					alignment : VerticalAlignment.top,
+					spacing   : horizontalSpacingBetweenColumns
+				) {
+					HStack(alignment: VerticalAlignment.top, spacing: 0) {
+						Spacer(minLength: 0) // => HorizontalAlignment.trailing
+						InfoGrid_Column0 {
+							Text("Fees")
+								.foregroundColor(.secondary)
+						}
+					}
+					.frame(width: widthColumn0)
+
+					Text(pFees.0.string) // pFees.0 => FormattedAmount
+						.onTapGesture { toggleCurrencyType() }
+				}
+			} // </if let pFees>
+			
+			if let pElapsed = payment.paymentTimeElapsed() {
+				
+				HStack(
+					alignment : VerticalAlignment.top,
+					spacing   : horizontalSpacingBetweenColumns
+				) {
+					HStack(alignment: VerticalAlignment.top, spacing: 0) {
+						Spacer(minLength: 0) // => HorizontalAlignment.trailing
+						InfoGrid_Column0 {
+							Text("Elapsed")
+								.foregroundColor(.secondary)
+						}
+					}
+					.frame(width: widthColumn0)
+
+					if pElapsed < 1_000 {
+						Text("\(pElapsed) milliseconds")
+					} else {
+						let seconds = pElapsed / 1_000
+						let millis = pElapsed % 1_000
+						
+						Text("\(seconds).\(millis) seconds")
+					}
+				}
+			} // </if let pElapsed>
+			
+			if let pError = payment.paymentFinalError() {
+				
+				HStack(
+					alignment : VerticalAlignment.top,
+					spacing   : horizontalSpacingBetweenColumns
+				) {
+					HStack(alignment: VerticalAlignment.top, spacing: 0) {
+						Spacer(minLength: 0) // => HorizontalAlignment.trailing
+						InfoGrid_Column0 {
+							Text("Error")
+								.foregroundColor(.secondary)
+						}
+					}
+					.frame(width: widthColumn0)
+
+					Text(pError)
+				}
+				
+			} // </if let pError>
+			
+		}
+		.padding([.leading, .trailing])
+		.onPreferenceChange(InfoGrid_Column0_MeasuredWidth.self) {
+			log.debug("InfoGrid_Column0_MeasuredWidth => \($0 ?? CGFloat(-1))")
+			if let width = $0 {
+				self.widthColumn0 = min(width, cappedWidthColumn0)
+			} else {
+				self.widthColumn0 = $0
+			}
+			
+		}
+	}
+	
+	func toggleCurrencyType() -> Void {
+		currencyPrefs.toggleCurrencyType()
+	}
+}
+
+struct InfoGrid_Column0<Content>: View where Content: View {
+	let content: Content
+	
+	init(@ViewBuilder builder: () -> Content) {
+		content = builder()
+	}
+	
+	var body: some View {
+		content
+			.background(GeometryReader { proxy in
+				Color.clear.preference(
+					key: InfoGrid_Column0_MeasuredWidth.self,
+					value: proxy.size.width
+				)
+			})
+	}
+}
+
+struct InfoGrid_Column0_MeasuredWidth: PreferenceKey {
+	static let defaultValue: CGFloat? = nil
+	
+	static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
+		
+		// This function is called with the measured width of each individual column0 item.
+		// We want to determine the maximum measured width here.
+		if let prv = value {
+			if let nxt = nextValue() {
+				value = prv >= nxt ? prv : nxt
+			} else {
+				value = prv
+			}
+		} else {
+			value = nextValue()
+		}
+	}
+}
+
+extension Eclair_kmpWalletPayment {
+	
+	fileprivate func paymentDescription() -> String? {
+		
+		if let incomingPayment = self as? Eclair_kmpIncomingPayment {
+			
+			if let invoice = incomingPayment.origin.asInvoice() {
+				return invoice.paymentRequest.desc()
+			}
+			
+		} else if let outgoingPayment = self as? Eclair_kmpOutgoingPayment {
+			
+			if let normal = outgoingPayment.details.asNormal() {
+				return normal.paymentRequest.desc()
+			}
+		}
+		
+		return nil
+	}
+	
+	fileprivate func paymentType() -> (String, String)? {
+		
+		if let incomingPayment = self as? Eclair_kmpIncomingPayment {
+			
+			if let _ = incomingPayment.origin.asSwapIn() {
+				let ttl = NSLocalizedString("SwapIn", comment: "Transaction Info: Type - title")
+				let exp = NSLocalizedString("layer 0 -> 1", comment: "Transaction Info: Type - explanation")
+				return (ttl, exp)
+			}
+			if let _ = incomingPayment.origin.asKeySend() {
+				let ttl = NSLocalizedString("KeySend", comment: "Transaction Info: Type - title")
+				let exp = NSLocalizedString("non-invoice payment", comment: "Transaction Info: Type - explanation")
+				return (ttl, exp)
+			}
+			
+		} else if let outgoingPayment = self as? Eclair_kmpOutgoingPayment {
+			
+			if let _ = outgoingPayment.details.asSwapOut() {
+				let ttl = NSLocalizedString("SwapIn", comment: "Transaction Info: Type - title")
+				let exp = NSLocalizedString("layer 1 -> 0", comment: "Transaction Info: Type - explanation")
+				return (ttl, exp)
+			}
+			if let _ = outgoingPayment.details.asKeySend() {
+				let ttl = NSLocalizedString("KeySend", comment: "Transaction Info: Type - title")
+				let exp = NSLocalizedString("non-invoice payment", comment: "Transaction Info: Type - explanation")
+				return (ttl, exp)
+			}
+		}
+		
+		return nil
+	}
+	
+	fileprivate func paymentLink() -> URL? {
+		
+		var address: String? = nil
+		if let incomingPayment = self as? Eclair_kmpIncomingPayment {
+		
+			if let swapIn = incomingPayment.origin.asSwapIn() {
+				address = swapIn.address
+			}
+			
+		} else if let outgoingPayment = self as? Eclair_kmpOutgoingPayment {
+		
+			if let swapOut = outgoingPayment.details.asSwapOut() {
+				address = swapOut.address
+			}
+		}
+		
+		if let address = address {
+			let str = "https://mempool.space/testnet/address/\(address)"
+			return URL(string: str)
+		}
+		
+		return nil
+	}
+	
+	fileprivate func paymentFees(currencyPrefs: CurrencyPrefs) -> (FormattedAmount, String)? {
+		
+		if let incomingPayment = self as? Eclair_kmpIncomingPayment {
+		
+			// An incomingPayment may have fees if a new channel was automatically opened
+			if let received = incomingPayment.received {
+				
+				let msat = received.receivedWith.fees.msat
+				if msat > 0 {
+					
+					let formattedAmt = Utils.format(currencyPrefs, msat: msat)
+					
+					let exp = NSLocalizedString(
+						"In order to receive this payment, a new payment channel was opened." +
+						" This is not always required.",
+						comment: "Fees explanation"
+					)
+					
+					return (formattedAmt, exp)
+				}
+			}
+			
+			
+		} else if let outgoingPayment = self as? Eclair_kmpOutgoingPayment {
+			
+			// no fees for failed payments
+			if let _ = outgoingPayment.status.asFailed() {
+				return nil
+			}
+			
+			let msat = outgoingPayment.fees.msat
+			let formattedAmt = Utils.format(currencyPrefs, msat: msat)
+			
+			var parts = 0
+			var hops = 0
+			for part in outgoingPayment.parts {
+				
+				parts += 1
+				hops = part.route.count
+			}
+			
+			let exp: String
+			if parts == 1 {
+				exp = NSLocalizedString("Paid in 1 part, using \(hops) hops",
+					comment: "Fees explanation")
+			} else {
+				exp = NSLocalizedString("Paid in \(parts) parts, using \(hops) hops",
+					comment: "Fees explanation")
+			}
+			
+			return (formattedAmt, exp)
+		}
+		
+		return nil
+	}
+	
+	/// If the OutgoingPayment succeeded or failed, reports the total elapsed time.
+	/// The return value is in number of milliseconds.
+	///
+	fileprivate func paymentTimeElapsed() -> Int64? {
+		
+		
+		if let outgoingPayment = self as? Eclair_kmpOutgoingPayment {
+			
+			let started = self.timestamp()
+			var finished: Int64? = nil
+			
+			if let failed = outgoingPayment.status.asFailed() {
+				finished = failed.completedAt
+				
+			} else if let succeeded = outgoingPayment.status.asSucceeded() {
+				finished = succeeded.completedAt
+			}
+			
+			if let finished = finished, finished > started {
+				return finished - started
+			}
+		}
+		
+		return nil
+	}
+	
+	fileprivate func paymentFinalError() -> String? {
+
+		if let outgoingPayment = self as? Eclair_kmpOutgoingPayment {
+			
+			if let failed = outgoingPayment.status.asFailed() {
+				
+				return failed.reason.description
+			}
+		}
+		
+		return nil
+	}
+}
+
+
+class PaymentView_Previews : PreviewProvider {
+	
+	static var previews: some View {
+		let mock = PhoenixShared.Mock()
+		
+		PaymentView(payment: mock.outgoingPending(), close: {})
+			.preferredColorScheme(.light)
+			.environmentObject(CurrencyPrefs.mockEUR())
+
+		PaymentView(payment: mock.outgoingSuccessful(), close: {})
+			.preferredColorScheme(.dark)
+			.environmentObject(CurrencyPrefs.mockEUR())
+
+		PaymentView(payment: mock.outgoingFailed(), close: {})
+			.preferredColorScheme(.dark)
+			.environmentObject(CurrencyPrefs.mockEUR())
+
+		PaymentView(payment: mock.incomingPaymentReceived(), close: {})
+			.preferredColorScheme(.dark)
+			.environmentObject(CurrencyPrefs.mockEUR())
+	}
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/PaymentsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/PaymentsManager.kt
@@ -8,6 +8,7 @@ import fr.acinq.eclair.io.PaymentNotSent
 import fr.acinq.eclair.io.PaymentProgress
 import fr.acinq.eclair.io.PaymentReceived
 import fr.acinq.eclair.io.PaymentSent
+import fr.acinq.eclair.payment.PaymentRequest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.MainScope
@@ -84,7 +85,7 @@ fun WalletPayment.desc(): String? = when (this) {
     }
 }.takeIf { !it.isNullOrBlank() }
 
-enum class WalletPaymentStatus { Success, Pending, Failure }
+enum class WalletPaymentState { Success, Pending, Failure }
 
 fun WalletPayment.amountMsat(): Long = when (this) {
     is OutgoingPayment -> -recipientAmount.msat
@@ -95,15 +96,16 @@ fun WalletPayment.id(): String = when (this) {
     is OutgoingPayment -> this.id.toString()
     is IncomingPayment -> this.paymentHash.toHex()
 }
-fun WalletPayment.status(): WalletPaymentStatus = when (this) {
+
+fun WalletPayment.state(): WalletPaymentState = when (this) {
     is OutgoingPayment -> when (status) {
-        is OutgoingPayment.Status.Pending -> WalletPaymentStatus.Pending
-        is OutgoingPayment.Status.Succeeded -> WalletPaymentStatus.Success
-        is OutgoingPayment.Status.Failed -> WalletPaymentStatus.Failure
+        is OutgoingPayment.Status.Pending -> WalletPaymentState.Pending
+        is OutgoingPayment.Status.Succeeded -> WalletPaymentState.Success
+        is OutgoingPayment.Status.Failed -> WalletPaymentState.Failure
     }
     is IncomingPayment -> when (received) {
-        null -> WalletPaymentStatus.Pending
-        else -> WalletPaymentStatus.Success
+        null -> WalletPaymentState.Pending
+        else -> WalletPaymentState.Success
     }
 }
 
@@ -116,3 +118,70 @@ fun WalletPayment.errorMessage(): String? = when (this) {
     }
     is IncomingPayment -> null
 }
+
+// Class type IncomingPayment.Origin.Invoice is not exported to iOS unless
+// we explicitly reference it in PhoenixShared.
+fun IncomingPayment.Origin.asInvoice(): IncomingPayment.Origin.Invoice? = when (this) {
+    is IncomingPayment.Origin.Invoice -> this
+    else -> null
+}
+
+// Class type IncomingPayment.Origin.KeySend is not exported to iOS unless
+// we explicitly reference it in PhoenixShared.
+fun IncomingPayment.Origin.asKeySend(): IncomingPayment.Origin.KeySend? = when (this) {
+    is IncomingPayment.Origin.KeySend -> this
+    else -> null
+}
+
+// Class type IncomingPayment.Origin.SwapIn is not exported to iOS unless
+// we explicitly reference it in PhoenixShared.
+fun IncomingPayment.Origin.asSwapIn(): IncomingPayment.Origin.SwapIn? = when (this) {
+    is IncomingPayment.Origin.SwapIn -> this
+    else -> null
+}
+
+// Class type OutgoingPayment.Details.Normal is not exported to iOS unless
+// we explicitly reference it in PhoenixShared.
+fun OutgoingPayment.Details.asNormal(): OutgoingPayment.Details.Normal? = when (this) {
+    is OutgoingPayment.Details.Normal -> this
+    else -> null
+}
+
+// Class type OutgoingPayment.Details.KeySend is not exported to iOS unless
+// we explicitly reference it in PhoenixShared.
+fun OutgoingPayment.Details.asKeySend(): OutgoingPayment.Details.KeySend? = when (this) {
+    is OutgoingPayment.Details.KeySend -> this
+    else -> null
+}
+
+// Class type OutgoingPayment.Details.SwapOut is not exported to iOS unless
+// we explicitly reference it in PhoenixShared.
+fun OutgoingPayment.Details.asSwapOut(): OutgoingPayment.Details.SwapOut? = when (this) {
+    is OutgoingPayment.Details.SwapOut -> this
+    else -> null
+}
+
+// Class type OutgoingPayment.Status.Pending is not exported to iOS unless
+// we explicitly reference it in PhoenixShared.
+fun OutgoingPayment.Status.asPending(): OutgoingPayment.Status.Pending? = when (this) {
+    is OutgoingPayment.Status.Pending -> this
+    else -> null
+}
+
+// Class type OutgoingPayment.Status.Failed is not exported to iOS unless
+// we explicitly reference it in PhoenixShared.
+fun OutgoingPayment.Status.asFailed(): OutgoingPayment.Status.Failed? = when (this) {
+    is OutgoingPayment.Status.Failed -> this
+    else -> null
+}
+
+// Class type OutgoingPayment.Status.Succeeded is not exported to iOS unless
+// we explicitly reference it in PhoenixShared.
+fun OutgoingPayment.Status.asSucceeded(): OutgoingPayment.Status.Succeeded? = when (this) {
+    is OutgoingPayment.Status.Succeeded -> this
+    else -> null
+}
+
+// In Objective-C, the function name `description()` is already in use (part of NSObject).
+// So we need to alias it.
+fun PaymentRequest.desc(): String? = this.description


### PR DESCRIPTION
This is phase 1 for the transaction screen. There are many more planned improvements, discussed below. But first, the improvements in this commit:

<img width="325" alt="Screen Shot 2021-02-02 at 15 42 56" src="https://user-images.githubusercontent.com/304604/106660615-3da58e00-656e-11eb-9978-d293d0739043.png">

The UI can now display a list of key/value pairs (whatever we may want). ^Notice^ how the pairs are vertically aligned. E.g. the keys ("Desc" & "Error" have matching trailing edges). Also notice how the key/value list (as a whole) is horizontally centered.

This was surprisingly difficult to do. But now it's done, and it will work as we add more keys, and as we add localizations.

However, now that we're displaying more information, we're starting to see bugs we didn't notice before:

<img width="325" alt="Screen Shot 2021-02-02 at 15 43 05" src="https://user-images.githubusercontent.com/304604/106661393-274c0200-656f-11eb-9bbf-92dbd25dc052.png">

- OutgoingPayment.fees is incorrect
- OutgoingPayment.status.succeeded.completedAt is incorrect (it's zero)

I think we want to limit the key/value pairs on this screen to high-level information that would be of interest to average users. Here's the current list, as per this commit:

- Description
- Error (if any) (as FinalError)
- Fees (with (?) button that displays popup with explanation for fee)
- Type (if KeySend/SwapIn/SwapOut) (with link to blockchain explorer)
- Time elapsed (for OutgoingPayments, I'd like to see how long it took to send)

The next step is to add a "Details" button, which can bring up an advanced screen with all the technical details.

Note: I'm currently considering the "Sent To" field to be technical information that should be moved to the advanced screen. An address such as "03f38cfd487a6f0063253..." isn't very useful to the average user.

Other changes scheduled for the future:
- The user should be able to add notes to the payment. (as in Android currently)
- The user should be able to modify the description. After all, the description is what we show on the Home screen. The original description is always available in the advanced screen.

Both of these require a separate metadata table for payments (as previously discussed). Another thing to add to the metadata table (as frequently requested from our users): the fiat conversion rates at the time of the transaction.