### PR TITLE
Fixes issue #129 - Cannot connect to Electrum server(s) when on mainnet

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConfigurationManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConfigurationManager.kt
@@ -3,6 +3,7 @@ package fr.acinq.phoenix.app
 import fr.acinq.eclair.WalletParams
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient
 import fr.acinq.eclair.blockchain.electrum.HeaderSubscriptionResponse
+import fr.acinq.eclair.io.TcpSocket
 import fr.acinq.eclair.utils.ServerAddress
 import fr.acinq.phoenix.data.*
 import fr.acinq.phoenix.db.SqliteAppDb
@@ -118,7 +119,7 @@ class AppConfigurationManager(
         Chain.MAINNET -> electrumMainnetConfigurations.random()
         Chain.TESTNET -> electrumTestnetConfigurations.random()
         Chain.REGTEST -> platformElectrumRegtestConf()
-    }.asServerAddress()
+    }.asServerAddress(tls = TcpSocket.TLS.SAFE)
 
     /** The flow containing the electrum header responses messages. */
     private val _electrumMessages by lazy { MutableStateFlow<HeaderSubscriptionResponse?>(null) }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppElectrumConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppElectrumConfigurationController.kt
@@ -1,6 +1,7 @@
 package fr.acinq.phoenix.app.ctrl.config
 
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient
+import fr.acinq.eclair.io.TcpSocket
 import fr.acinq.phoenix.app.AppConfigurationManager
 import fr.acinq.phoenix.app.ctrl.AppController
 import fr.acinq.phoenix.ctrl.config.ElectrumConfiguration
@@ -53,7 +54,11 @@ class AppElectrumConfigurationController(
                         intent.address.split(":").let {
                             val host = it.first()
                             val port = it.last()
-                            configurationManager.updateElectrumConfig(ElectrumAddress(host, port.toInt()).asServerAddress())
+                            val addr = ElectrumAddress(
+                                host = host,
+                                sslPort = port.toInt()
+                            ).asServerAddress(tls = TcpSocket.TLS.SAFE)
+                            configurationManager.updateElectrumConfig(addr)
                         }
                     }
                 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/electrumConfs.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/electrumConfs.kt
@@ -9,7 +9,8 @@ data class ElectrumAddress(
     val tcpPort: Int = 50001,
     val version: String = "1.4"
 ) {
-    fun asServerAddress(tls: TcpSocket.TLS? = null): ServerAddress = ServerAddress(host, port = if (tls != null) sslPort else tcpPort, tls)
+    fun asServerAddress(tls: TcpSocket.TLS?): ServerAddress =
+        ServerAddress(host, port = if (tls != null) sslPort else tcpPort, tls)
 }
 
 val electrumMainnetConfigurations = listOf(


### PR DESCRIPTION
The issue seemed to be when we converted from `ElectrumAddress` to `ServerAddress`:

Old code:
```kotlin
data class ElectrumAddress(
    val host: String,
    val sslPort: Int = 50002,
    val tcpPort: Int = 50001,
    val version: String = "1.4"
) {
    fun asServerAddress(tls: TcpSocket.TLS? = null): ServerAddress =
        ServerAddress(host, port = if (tls != null) sslPort else tcpPort, tls)
}
```

The problem was that it was always called as:
```kotlin
electrumAddress.asServerAddress()
```

Which meant we were always using a server address with the `tcpPort`, and `tls = null`.

I changed it to make the `tls` parameter non-optional:
```kotlin
fun asServerAddress(tls: TcpSocket.TLS?): ServerAddress
```

And now we always call it with `.asServerAddress(tls = TcpSocket.TLS.SAFE)`