### PR TITLE
Segregate database files with chain/node id

### DIFF
--- a/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/db/androidDbFactory.kt
+++ b/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/db/androidDbFactory.kt
@@ -18,14 +18,16 @@ package fr.acinq.phoenix.db
 
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 import com.squareup.sqldelight.db.SqlDriver
+import fr.acinq.phoenix.data.Chain
 import fr.acinq.phoenix.utils.PlatformContext
+import java.util.*
 
-actual fun createChannelsDbDriver(ctx: PlatformContext): SqlDriver {
-    return AndroidSqliteDriver(ChannelsDatabase.Schema, ctx.applicationContext, "channels.sqlite")
+actual fun createChannelsDbDriver(ctx: PlatformContext, chain: Chain, nodeIdHash: String): SqlDriver {
+    return AndroidSqliteDriver(ChannelsDatabase.Schema, ctx.applicationContext, "channels-${chain.name.toLowerCase(Locale.ROOT)}-$nodeIdHash.sqlite")
 }
 
-actual fun createPaymentsDbDriver(ctx: PlatformContext): SqlDriver {
-    return AndroidSqliteDriver(PaymentsDatabase.Schema, ctx.applicationContext, "payments.sqlite")
+actual fun createPaymentsDbDriver(ctx: PlatformContext, chain: Chain, nodeIdHash: String): SqlDriver {
+    return AndroidSqliteDriver(PaymentsDatabase.Schema, ctx.applicationContext, "payments-${chain.name.toLowerCase(Locale.ROOT)}-$nodeIdHash.sqlite")
 }
 
 actual fun createAppDbDriver(ctx: PlatformContext): SqlDriver {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
@@ -58,7 +58,6 @@ class PhoenixBusiness(private val ctx: PlatformContext) {
     }
 
     private val appDb by lazy { SqliteAppDb(createAppDbDriver(ctx)) }
-    private val paymentsDb by lazy { SqlitePaymentsDb(createPaymentsDbDriver(ctx)) }
 
     public val chain = Chain.Testnet
 
@@ -68,8 +67,8 @@ class PhoenixBusiness(private val ctx: PlatformContext) {
     private var appConnectionsDaemon: AppConnectionsDaemon? = null
 
     private val walletManager by lazy { WalletManager() }
-    private val peerManager by lazy { PeerManager(loggerFactory, walletManager, appConfigurationManager, paymentsDb, tcpSocketBuilder, electrumWatcher, chain, ctx) }
-    val paymentsManager by lazy { PaymentsManager(loggerFactory, paymentsDb, peerManager) }
+    private val peerManager by lazy { PeerManager(loggerFactory, walletManager, appConfigurationManager, tcpSocketBuilder, electrumWatcher, chain, ctx) }
+    val paymentsManager by lazy { PaymentsManager(loggerFactory, peerManager) }
     val appConfigurationManager by lazy { AppConfigurationManager(appDb, httpClient, electrumClient, chain, loggerFactory) }
 
     val currencyManager by lazy { CurrencyManager(loggerFactory, appDb, httpClient) }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/DbFactory.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/DbFactory.kt
@@ -17,10 +17,12 @@
 package fr.acinq.phoenix.db
 
 import com.squareup.sqldelight.db.SqlDriver
+import fr.acinq.bitcoin.PublicKey
+import fr.acinq.phoenix.data.Chain
 import fr.acinq.phoenix.utils.PlatformContext
 
-expect fun createChannelsDbDriver(ctx: PlatformContext): SqlDriver
+expect fun createChannelsDbDriver(ctx: PlatformContext, chain: Chain, nodeIdHash: String): SqlDriver
 
-expect fun createPaymentsDbDriver(ctx: PlatformContext): SqlDriver
+expect fun createPaymentsDbDriver(ctx: PlatformContext, chain: Chain, nodeIdHash: String): SqlDriver
 
 expect fun createAppDbDriver(ctx: PlatformContext): SqlDriver

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/iosDbFactory.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/iosDbFactory.kt
@@ -18,14 +18,15 @@ package fr.acinq.phoenix.db
 
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
+import fr.acinq.phoenix.data.Chain
 import fr.acinq.phoenix.utils.PlatformContext
 
-actual fun createChannelsDbDriver(ctx: PlatformContext): SqlDriver {
-    return NativeSqliteDriver(ChannelsDatabase.Schema, "channels.sqlite")
+actual fun createChannelsDbDriver(ctx: PlatformContext, chain: Chain, nodeIdHash: String): SqlDriver {
+    return NativeSqliteDriver(ChannelsDatabase.Schema, "channels-${chain.name.toLowerCase()}-$nodeIdHash.sqlite")
 }
 
-actual fun createPaymentsDbDriver(ctx: PlatformContext): SqlDriver {
-    return NativeSqliteDriver(PaymentsDatabase.Schema, "payments.sqlite")
+actual fun createPaymentsDbDriver(ctx: PlatformContext, chain: Chain, nodeIdHash: String): SqlDriver {
+    return NativeSqliteDriver(PaymentsDatabase.Schema, "payments-${chain.name.toLowerCase()}-$nodeIdHash.sqlite")
 }
 
 actual fun createAppDbDriver(ctx: PlatformContext): SqlDriver {


### PR DESCRIPTION
The payments and channels database file names now contain the chain and
a hash of the node id. This will let the app know what database can be
used for what node id.

We do not use the node id directly to avoid leaking information in in cases those 
files are backed up on a cloud solution.