### PR TITLE
Change default explorer from blockstream.info to mempool.space

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
@@ -60,7 +60,7 @@ class AppChannelsConfigurationController(
                             ),
                             txUrl = if (state is ChannelStateWithCommitments) {
                                 val txId = state.commitments.commitInput.outPoint.txid
-                                val base = "https://blockstream.info"
+                                val base = "https://mempool.space"
                                 when (chain) {
                                     Chain.Mainnet -> "$base/tx/$txId"
                                     Chain.Testnet -> "$base/testnet/tx/$txId"


### PR DESCRIPTION
This PR changes the default explorer to mempool.space so that Phoenix Wallet on iOS matches Phoenix Wallet on Android