### PR TITLE
Improve feedback when scanning unsupported data

### DIFF
--- a/phoenix-ios/phoenix-ios/views/SendView.swift
+++ b/phoenix-ios/phoenix-ios/views/SendView.swift
@@ -44,8 +44,8 @@ struct SendView: MVIView {
 		.frame(maxWidth: .infinity, maxHeight: .infinity)
 		.onChange(of: mvi.model, perform: { newModel in
 
-			if newModel is Scan.ModelBadRequest {
-				toast.toast(text: "Unexpected request format!")
+			if let newModel = newModel as? Scan.ModelBadRequest {
+				showErrorToast(newModel)
 			}
 			else if let model = newModel as? Scan.ModelDangerousRequest {
 				paymentRequest = model.request
@@ -87,6 +87,44 @@ struct SendView: MVIView {
 		default:
 			fatalError("Unknown model \(mvi.model)")
 		}
+	}
+	
+	func showErrorToast(_ model: Scan.ModelBadRequest) -> Void {
+		log.trace("showErrorToast()")
+		
+		let msg: String
+		if let reason = model.reason as? Scan.BadRequestReasonChainMismatch {
+			
+			let requestChain = reason.requestChain?.name ?? "unknown"
+			msg = NSLocalizedString(
+				"The invoice is for \(requestChain), but you're on \(reason.myChain.name)",
+				comment: "Error message - scanning lightning invoice"
+			)
+			
+		} else if model.reason is Scan.BadRequestReasonIsBitcoinAddress {
+			
+			msg = NSLocalizedString(
+				"You scanned a bitcoin address. Phoenix currently only supports sending Lightning payments." +
+				" You can use a third-party service to make the offchain->onchain swap.",
+				comment: "Error message - scanning lightning invoice"
+			)
+			
+		} else {
+		
+			msg = NSLocalizedString(
+				"This doesn't appear to be a Lightning invoice",
+				comment: "Error message - scanning lightning invoice"
+			)
+		}
+		
+		toast.toast(
+			text: msg,
+			duration: 30,
+			location: .middle,
+			showCloseButton: true,
+			backgroundColor: Color.black.opacity(0.9),
+			foregroundColor: Color.white
+		)
 	}
 	
 	func didReceiveExternalLightningUrl(_ url: URL) -> Void {
@@ -186,7 +224,7 @@ struct ScanView: View {
 		ignoreScanner = true
 		popoverState.display.send(PopoverItem(
 			
-			PopupAlert(
+			DangerousInvoiceAlert(
 				postIntent: mvi.intent,
 				paymentRequest: paymentRequest!,
 				isShowing: $isWarningDisplayed,
@@ -197,7 +235,7 @@ struct ScanView: View {
 	}
 }
 
-struct PopupAlert : View {
+struct DangerousInvoiceAlert : View {
 
 	let postIntent: (Scan.Intent) -> Void
 	let paymentRequest: String
@@ -238,7 +276,7 @@ struct PopupAlert : View {
 					
 				Spacer()
 					
-				Button("Confirm") {
+				Button("Continue") {
 					isShowing = false
 					postIntent(Scan.IntentConfirmDangerousRequest(request: paymentRequest))
 					popoverState.close.send()

--- a/phoenix-ios/phoenix-ios/views/SendView.swift
+++ b/phoenix-ios/phoenix-ios/views/SendView.swift
@@ -100,6 +100,13 @@ struct SendView: MVIView {
 				"The invoice is for \(requestChain), but you're on \(reason.myChain.name)",
 				comment: "Error message - scanning lightning invoice"
 			)
+		
+		} else if model.reason is Scan.BadRequestReasonIsLnUrl {
+			
+			msg = NSLocalizedString(
+				"Phoenix does not support the LNURL protocol yet",
+				comment: "Error message - scanning lightning invoice"
+			)
 			
 		} else if model.reason is Scan.BadRequestReasonIsBitcoinAddress {
 			

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
@@ -139,7 +139,7 @@ class PhoenixBusiness(private val ctx: PlatformContext) {
             AppReceiveController(loggerFactory, chain, peerManager)
 
         override fun scan(firstModel: Scan.Model): ScanController =
-            AppScanController(loggerFactory, firstModel, peerManager)
+            AppScanController(loggerFactory, firstModel, peerManager, util, chain)
 
         override fun restoreWallet(): RestoreWalletController =
             AppRestoreWalletController(loggerFactory)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppScanController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppScanController.kt
@@ -9,10 +9,13 @@ import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.io.SendPayment
 import fr.acinq.lightning.payment.PaymentRequest
+import fr.acinq.lightning.utils.Either
 import fr.acinq.lightning.utils.UUID
 import fr.acinq.lightning.utils.sum
 import fr.acinq.phoenix.app.PeerManager
+import fr.acinq.phoenix.app.Utilities
 import fr.acinq.phoenix.ctrl.Scan
+import fr.acinq.phoenix.data.Chain
 import fr.acinq.phoenix.data.toMilliSatoshi
 import fr.acinq.phoenix.utils.localCommitmentSpec
 import kotlinx.coroutines.flow.collect
@@ -22,7 +25,9 @@ import org.kodein.log.LoggerFactory
 class AppScanController(
     loggerFactory: LoggerFactory,
     firstModel: Scan.Model?,
-    private val peerManager: PeerManager
+    private val peerManager: PeerManager,
+    private val utilities: Utilities,
+    private val chain: Chain
 ) : AppController<Scan.Model, Scan.Intent>(
     loggerFactory,
     firstModel = firstModel ?: Scan.Model.Ready
@@ -58,42 +63,114 @@ class AppScanController(
     override fun process(intent: Scan.Intent) {
         when (intent) {
             is Scan.Intent.Parse -> launch {
-                readPaymentRequest(intent.request)?.run {
-                    var isDangerous = if (amount != null) {
-                        false
-                    } else {
-                        // amountless invoice -> dangerous unless full trampoline is in effect
-                        !Features(features ?: ByteVector.empty).hasFeature(Feature.TrampolinePayment)
+                when (val result = readPaymentRequest(intent.request)) {
+                    is Either.Left -> { // result.value: Scan.BadRequestReason
+                        model(Scan.Model.BadRequest(result.value))
                     }
-                    if (isDangerous)
-                        model(Scan.Model.DangerousRequest(intent.request))
-                    else
-                        validatePaymentRequest(intent.request, this)
+                    is Either.Right -> {
+                        val paymentRequest: PaymentRequest = result.value
+                        var isDangerous = if (paymentRequest.amount != null) {
+                            false
+                        } else {
+                            // amountless invoice -> dangerous unless full trampoline is in effect
+                            val features = Features(paymentRequest.features ?: ByteVector.empty)
+                            !features.hasFeature(Feature.TrampolinePayment)
+                        }
+                        if (isDangerous)
+                            model(Scan.Model.DangerousRequest(intent.request))
+                        else
+                            validatePaymentRequest(intent.request, paymentRequest)
+                    }
                 }
             }
             is Scan.Intent.ConfirmDangerousRequest -> launch {
-                readPaymentRequest(intent.request)?.run {
-                    validatePaymentRequest(intent.request, this)
+                when (val result = readPaymentRequest(intent.request)) {
+                    is Either.Left -> { // result.value: Scan.BadRequestReason
+                        model(Scan.Model.BadRequest(result.value))
+                    }
+                    is Either.Right -> { // result.value: PaymentRequest
+                        validatePaymentRequest(intent.request, result.value)
+                    }
                 }
             }
             is Scan.Intent.Send -> {
                 launch {
-                    readPaymentRequest(intent.request)?.let {
-                        val paymentId = UUID.randomUUID()
-                        peerManager.getPeer().send(SendPayment(paymentId, intent.amount, it.nodeId, OutgoingPayment.Details.Normal(it)))
-                        model(Scan.Model.Sending)
+                    when (val result = readPaymentRequest((intent.request))) {
+                        is Either.Left -> { // result.value: Scan.BadRequestReason
+                            model(Scan.Model.BadRequest(result.value))
+                        }
+                        is Either.Right -> {
+                            val paymentRequest: PaymentRequest = result.value
+                            val paymentId = UUID.randomUUID()
+                            peerManager.getPeer().send(
+                                SendPayment(
+                                    paymentId = paymentId,
+                                    amount = intent.amount,
+                                    recipient = paymentRequest.nodeId,
+                                    details = OutgoingPayment.Details.Normal(paymentRequest)
+                                )
+                            )
+                            model(Scan.Model.Sending)
+                        }
                     }
                 }
             }
         }
     }
 
-    private suspend fun readPaymentRequest(request: String) : PaymentRequest? {
-        return try {
-            PaymentRequest.read(request.cleanUpInvoice())
-        } catch (t: Throwable) { // TODO Throwable is not a good choice, analyze the possible output of PaymentRequest.read(...)
-            model(Scan.Model.BadRequest)
-            null
+    private suspend fun readPaymentRequest(
+        input: String
+    ) : Either<Scan.BadRequestReason, PaymentRequest> {
+
+        var request = input.replace("\\u00A0", "").trim() // \u00A0 = '\n'
+        request = when {
+            request.startsWith("lightning://", true) -> request.drop(12)
+            request.startsWith("lightning:", true) -> request.drop(10)
+            request.startsWith("bitcoin://", true) -> request.drop(10)
+            request.startsWith("bitcoin:", true) -> request.drop(8)
+            else -> request
+        }
+
+        try {
+            val paymentRequest = PaymentRequest.read(request) // <- throws
+            val requestChain = when (paymentRequest.prefix) {
+                "lnbc" -> Chain.Mainnet
+                "lntb" -> Chain.Testnet
+                "lnbcrt" -> Chain.Regtest
+                else -> null
+            }
+            return if (chain != requestChain) {
+                Either.Left(Scan.BadRequestReason.ChainMismatch(chain, requestChain))
+            } else {
+                Either.Right(paymentRequest)
+            }
+        } catch (t: Throwable) {
+            // The qrcode doesn't appear to be for a lightning invoice.
+            // Is it for a bitcoin address ?
+            return when (val result = utilities.parseBitcoinAddress(input)) {
+                is Either.Left -> {
+                    val reason: Utilities.BitcoinAddressError = result.value
+                    when (reason) {
+                        is Utilities.BitcoinAddressError.ChainMismatch -> {
+                            // Two problems here:
+                            // - they're scanning a bitcoin address, but we don't support swap-out yet
+                            // - the bitcoin address is for the wrong chain
+                            Either.Left(Scan.BadRequestReason.ChainMismatch(
+                                myChain = reason.myChain,
+                                requestChain = reason.addrChain
+                            ))
+                        }
+                        else -> {
+                            Either.Left(Scan.BadRequestReason.UnknownFormat)
+                        }
+                    }
+                }
+                is Either.Right -> {
+                    // Yup, it's a bitcoin address.
+                    // But we don't support swap-out yet.
+                    Either.Left(Scan.BadRequestReason.IsBitcoinAddress)
+                }
+            }
         }
     }
 
@@ -112,16 +189,4 @@ class AppScanController(
             )
         )
     }
-
-    private fun String.cleanUpInvoice(): String {
-        val trimmed = replace("\\u00A0", "").trim()
-        return when {
-            trimmed.startsWith("lightning://", true) -> trimmed.drop(12)
-            trimmed.startsWith("lightning:", true) -> trimmed.drop(10)
-            trimmed.startsWith("bitcoin://", true) -> trimmed.drop(10)
-            trimmed.startsWith("bitcoin:", true) -> trimmed.drop(8)
-            else -> trimmed
-        }
-    }
-
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppScanController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppScanController.kt
@@ -146,6 +146,16 @@ class AppScanController(
             }
         } catch (t: Throwable) {
             // The qrcode doesn't appear to be for a lightning invoice.
+            // Is it a LNURL ?
+            val isLnUrl = when {
+                input.startsWith("lightning://lnurl1", true) -> true
+                input.startsWith("lightning:lnurl1", true) -> true
+                input.startsWith("lnurl1", true) -> true
+                else -> false
+            }
+            if (isLnUrl) {
+                return Either.Left(Scan.BadRequestReason.isLnUrl)
+            }
             // Is it for a bitcoin address ?
             return when (val result = utilities.parseBitcoinAddress(input)) {
                 is Either.Left -> {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/ScanController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/ScanController.kt
@@ -2,15 +2,22 @@ package fr.acinq.phoenix.ctrl
 
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.phoenix.data.BitcoinUnit
+import fr.acinq.phoenix.data.Chain
 
 
 typealias ScanController = MVI.Controller<Scan.Model, Scan.Intent>
 
 object Scan {
 
+    sealed class BadRequestReason {
+        data class ChainMismatch(val myChain: Chain, val requestChain: Chain?): BadRequestReason()
+        object IsBitcoinAddress: BadRequestReason()
+        object UnknownFormat: BadRequestReason()
+    }
+
     sealed class Model : MVI.Model() {
         object Ready: Model()
-        object BadRequest: Model()
+        data class BadRequest(val reason: BadRequestReason): Model()
         data class DangerousRequest(val request: String): Model()
         data class Validate(
             val request: String,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/ScanController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/ScanController.kt
@@ -11,6 +11,7 @@ object Scan {
 
     sealed class BadRequestReason {
         data class ChainMismatch(val myChain: Chain, val requestChain: Chain?): BadRequestReason()
+        object isLnUrl: BadRequestReason()
         object IsBitcoinAddress: BadRequestReason()
         object UnknownFormat: BadRequestReason()
     }


### PR DESCRIPTION
Displays a warning if the user scans:

- bitcoin address
- lnurl
- lightning invoice for wrong chain
- something else that isn't a lightning invoice

![IMG_3364](https://user-images.githubusercontent.com/304604/115621907-23559380-a2c5-11eb-933e-3df2cbec1459.jpeg)

The dialog appears in the middle of the screen. It auto-dismisses after 30 seconds. And a close button has been added.

Please check my logic in AppScanController.kt, especially with regards to LNURL's.

Fixes issue #154 
Fixes issue #155