### PR TITLE
Use lightning-kmp v2 serialization when reading channels

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
@@ -42,9 +42,9 @@ class AppChannelsConfigurationController(
                     peer.nodeParams.keyManager.nodeId.toString(),
                     json.encodeToString(MapSerializer(
                         ByteVector32KSerializer,
-                        fr.acinq.lightning.serialization.v1.ChannelState.serializer()
+                        fr.acinq.lightning.serialization.v2.ChannelState.serializer()
                     ),
-                    it.mapValues { m ->  fr.acinq.lightning.serialization.v1.ChannelState.import(m.value) } ),
+                    it.mapValues { m ->  fr.acinq.lightning.serialization.v2.ChannelState.import(m.value) } ),
                     it.map { (id, state) ->
                         ChannelsConfiguration.Model.Channel(
                             id = id.toHex(),
@@ -55,8 +55,8 @@ class AppChannelsConfigurationController(
                                     .toLong() to (it.toLocal + it.toRemote).truncateToSatoshi().toLong()
                             },
                             json = json.encodeToString(
-                                fr.acinq.lightning.serialization.v1.ChannelState.serializer(),
-                                fr.acinq.lightning.serialization.v1.ChannelState.import(state)
+                                fr.acinq.lightning.serialization.v2.ChannelState.serializer(),
+                                fr.acinq.lightning.serialization.v2.ChannelState.import(state)
                             ),
                             txUrl = if (state is ChannelStateWithCommitments) {
                                 val txId = state.commitments.commitInput.outPoint.txid

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
@@ -2,8 +2,8 @@ package fr.acinq.phoenix.app.ctrl.config
 
 import fr.acinq.lightning.channel.ChannelStateWithCommitments
 import fr.acinq.lightning.channel.Normal
-import fr.acinq.lightning.serialization.v2.ByteVector32KSerializer
-import fr.acinq.lightning.serialization.v2.Serialization.lightningSerializersModule
+import fr.acinq.lightning.serialization.v1.ByteVector32KSerializer
+import fr.acinq.lightning.serialization.v1.Serialization.lightningSerializersModule
 import fr.acinq.phoenix.app.PeerManager
 import fr.acinq.phoenix.app.ctrl.AppController
 import fr.acinq.phoenix.ctrl.config.ChannelsConfiguration
@@ -37,15 +37,19 @@ class AppChannelsConfigurationController(
         launch {
             val peer = peerManager.getPeer()
 
-            peer.channelsFlow.collect {
+            peer.channelsFlow.collect { channels ->
                 model(ChannelsConfiguration.Model(
-                    peer.nodeParams.keyManager.nodeId.toString(),
-                    json.encodeToString(MapSerializer(
-                        ByteVector32KSerializer,
-                        fr.acinq.lightning.serialization.v2.ChannelState.serializer()
+                    nodeId = peer.nodeParams.keyManager.nodeId.toString(),
+                    json = json.encodeToString(
+                        serializer = MapSerializer(
+                            ByteVector32KSerializer,
+                            fr.acinq.lightning.serialization.v1.ChannelState.serializer()
+                        ),
+                        value = channels.mapValues {
+                            fr.acinq.lightning.serialization.v1.ChannelState.import(it.value)
+                        }
                     ),
-                    it.mapValues { m ->  fr.acinq.lightning.serialization.v2.ChannelState.import(m.value) } ),
-                    it.map { (id, state) ->
+                    channels = channels.map { (id, state) ->
                         ChannelsConfiguration.Model.Channel(
                             id = id.toHex(),
                             isOk = state is Normal,
@@ -55,8 +59,8 @@ class AppChannelsConfigurationController(
                                     .toLong() to (it.toLocal + it.toRemote).truncateToSatoshi().toLong()
                             },
                             json = json.encodeToString(
-                                fr.acinq.lightning.serialization.v2.ChannelState.serializer(),
-                                fr.acinq.lightning.serialization.v2.ChannelState.import(state)
+                                fr.acinq.lightning.serialization.v1.ChannelState.serializer(),
+                                fr.acinq.lightning.serialization.v1.ChannelState.import(state)
                             ),
                             txUrl = if (state is ChannelStateWithCommitments) {
                                 val txId = state.commitments.commitInput.outPoint.txid

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
@@ -2,8 +2,8 @@ package fr.acinq.phoenix.app.ctrl.config
 
 import fr.acinq.lightning.channel.ChannelStateWithCommitments
 import fr.acinq.lightning.channel.Normal
-import fr.acinq.lightning.serialization.ByteVector32KSerializer
-import fr.acinq.lightning.serialization.Serialization.lightningSerializersModule
+import fr.acinq.lightning.serialization.v2.ByteVector32KSerializer
+import fr.acinq.lightning.serialization.v2.Serialization.lightningSerializersModule
 import fr.acinq.phoenix.app.PeerManager
 import fr.acinq.phoenix.app.ctrl.AppController
 import fr.acinq.phoenix.ctrl.config.ChannelsConfiguration

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingReceivedWithType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingReceivedWithType.kt
@@ -19,7 +19,7 @@ package fr.acinq.phoenix.db.payments
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.db.IncomingPayment
-import fr.acinq.lightning.serialization.ByteVector32KSerializer
+import fr.acinq.lightning.serialization.v1.ByteVector32KSerializer
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlinx.serialization.SerialName

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingDetailsType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingDetailsType.kt
@@ -19,7 +19,7 @@ package fr.acinq.phoenix.db.payments
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.payment.PaymentRequest
-import fr.acinq.lightning.serialization.ByteVector32KSerializer
+import fr.acinq.lightning.serialization.v1.ByteVector32KSerializer
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlinx.serialization.Serializable

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingPartStatusType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingPartStatusType.kt
@@ -18,7 +18,7 @@ package fr.acinq.phoenix.db.payments
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.db.OutgoingPayment
-import fr.acinq.lightning.serialization.ByteVector32KSerializer
+import fr.acinq.lightning.serialization.v1.ByteVector32KSerializer
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
 import kotlinx.serialization.Serializable

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingStatusType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingStatusType.kt
@@ -21,8 +21,8 @@ import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.db.ChannelClosingType
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.payment.FinalFailure
-import fr.acinq.lightning.serialization.ByteVector32KSerializer
-import fr.acinq.lightning.serialization.SatoshiKSerializer
+import fr.acinq.lightning.serialization.v1.ByteVector32KSerializer
+import fr.acinq.lightning.serialization.v1.SatoshiKSerializer
 import fr.acinq.phoenix.db.payments.DbTypesHelper.decodeBlob
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*


### PR DESCRIPTION
See https://github.com/ACINQ/lightning-kmp/pull/262 for details.

Note that for channel json details, we still use v1 serialization which is more readable.