### PR TITLE
Select a random electrum server on each connection attempt

### DIFF
--- a/phoenix-ios/phoenix-ios/views/configuration/general/ElectrumConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/general/ElectrumConfigurationView.swift
@@ -33,7 +33,11 @@ struct ElectrumConfigurationView: MVIView {
 	func connectionAddress() -> String {
 		
 		if mvi.model.connection == .established || mvi.model.isCustom() {
-			return mvi.model.configuration?.server.host ?? ""
+			if let customConfig = mvi.model.configuration as? ElectrumConfig.Custom {
+				return customConfig.server.host
+			} else {
+				return ""
+			}
 		} else {
 			return NSLocalizedString("Random server", comment: "Connection info")
 		}
@@ -145,6 +149,15 @@ struct ElectrumConfigurationView: MVIView {
 				showing: $isModifying
 			).padding()
 		}
+		.onAppear {
+			onAppear()
+		}
+	}
+	
+	func onAppear() -> Void {
+		log.trace("onAppear()")
+		
+		log.debug("mvi.model: \(mvi.model)")
 	}
 	
 	struct ListHeader: View {
@@ -212,8 +225,9 @@ struct ElectrumAddressPopup: View {
 		_showing = showing
 		
 		_isCustomized = State(initialValue: model.isCustom())
-		let host = model.configuration?.server.host ?? ""
-		let port = model.configuration?.server.port ?? 0
+		let customConfig = model.configuration as? ElectrumConfig.Custom
+		let host = customConfig?.server.host ?? ""
+		let port = customConfig?.server.port ?? 0
 		
 		if model.isCustom() && host.count > 0 {
 			_host = State(initialValue: host)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
@@ -148,7 +148,7 @@ class PhoenixBusiness(private val ctx: PlatformContext) {
             AppConfigurationController(loggerFactory, walletManager)
 
         override fun electrumConfiguration(): ElectrumConfigurationController =
-            AppElectrumConfigurationController(loggerFactory, appConfigurationManager, electrumClient)
+            AppElectrumConfigurationController(loggerFactory, appConfigurationManager, electrumClient, appConnectionsDaemon!!)
 
         override fun channelsConfiguration(): ChannelsConfigurationController =
             AppChannelsConfigurationController(loggerFactory, peerManager, chain)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConfigurationManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConfigurationManager.kt
@@ -114,9 +114,18 @@ class AppConfigurationManager(
     private val _electrumConfig by lazy { MutableStateFlow<ElectrumConfig?>(null) }
     fun electrumConfig(): StateFlow<ElectrumConfig?> = _electrumConfig
 
+    fun electrumServerAddress(): ServerAddress? {
+        return _electrumConfig.value?.let {
+            when (it) {
+                is ElectrumConfig.Custom -> it.server
+                is ElectrumConfig.Random -> randomElectrumServer()
+            }
+        }
+    }
+
     /** Use this method to set a server to connect to. If null, will connect to a random server. */
     fun updateElectrumConfig(server: ServerAddress?) {
-        _electrumConfig.value = server?.let { ElectrumConfig.Custom(it) } ?: ElectrumConfig.Random(randomElectrumServer())
+        _electrumConfig.value = server?.let { ElectrumConfig.Custom(it) } ?: ElectrumConfig.Random
     }
 
     private fun randomElectrumServer() = when (chain) {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConnectionsDaemon.kt
@@ -2,6 +2,7 @@ package fr.acinq.phoenix.app
 
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
 import fr.acinq.lightning.utils.Connection
+import fr.acinq.lightning.utils.ServerAddress
 import fr.acinq.phoenix.data.ElectrumConfig
 import fr.acinq.phoenix.utils.NetworkMonitor
 import fr.acinq.phoenix.utils.NetworkState
@@ -72,6 +73,8 @@ class AppConnectionsDaemon(
     private val httpApiControlFlow = MutableStateFlow(TrafficControl())
     private val httpApiControlChanges = Channel<TrafficControl.() -> TrafficControl>()
 
+    var lastElectrumServerAddress: ServerAddress? = null
+
     init {
         fun enableControlFlow(
             label: String,
@@ -99,13 +102,14 @@ class AppConnectionsDaemon(
                                 name = "Electrum",
                                 statusStateFlow = electrumClient.connectionState
                             ) {
-                                val electrumConfig = configurationManager.electrumConfig().value
-                                if (electrumConfig == null) {
+                                val electrumServerAddress = configurationManager.electrumServerAddress()
+                                if (electrumServerAddress == null) {
                                     logger.info { "ignored electrum connection opportunity because no server is configured yet" }
                                 } else {
-                                    logger.info { "connecting to electrum using config=$electrumConfig" }
-                                    electrumClient.connect(electrumConfig.server)
+                                    logger.info { "connecting to electrum server=$electrumServerAddress" }
+                                    electrumClient.connect(electrumServerAddress)
                                 }
+                                lastElectrumServerAddress = electrumServerAddress
                             }
                         }
                     }
@@ -208,18 +212,46 @@ class AppConnectionsDaemon(
         // listen to electrum configuration changes and reconnect when needed.
         launch {
             var previousElectrumConfig: ElectrumConfig? = null
-            configurationManager.electrumConfig().collect { config ->
-                if (config == null) {
+            configurationManager.electrumConfig().collect { newElectrumConfig ->
+                val changed = when (val oldElectrumConfig = previousElectrumConfig) {
+                    is ElectrumConfig.Custom -> {
+                        when (newElectrumConfig) {
+                            is ElectrumConfig.Custom -> { // custom -> custom
+                                newElectrumConfig.server.host != oldElectrumConfig.server.host ||
+                                newElectrumConfig.server.port != oldElectrumConfig.server.port
+                            }
+                            is ElectrumConfig.Random -> true // custom -> random
+                            else -> true // custom -> null
+                        }
+                    }
+                    is ElectrumConfig.Random -> {
+                        when (newElectrumConfig) {
+                            is ElectrumConfig.Custom -> true // random -> custom
+                            is ElectrumConfig.Random -> false // random -> random
+                            else -> true // random -> null
+                        }
+                    }
+                    else -> {
+                        when (newElectrumConfig) {
+                            null -> false // null -> null
+                            else -> true // null -> (custom || random)
+                        }
+                    }
+                }
+                if (changed) {
+                    logger.info { "electrum server config changed to=$newElectrumConfig, reconnecting..." }
                     electrumControlChanges.send { incrementDisconnectCount() }
-                } else if (config.server.host != previousElectrumConfig?.server?.host) {
-                    logger.info { "electrum server config updated to=$config, reconnecting..." }
-                    electrumControlChanges.send { incrementDisconnectCount() }
-                    delay(500)
+                    if (previousElectrumConfig != null) {
+                        // The electrumConfig is only null on app launch.
+                        // It gets set by the client app during launch,
+                        // and from that point forward it's either Custom or Random.
+                        delay(500)
+                    }
                     // We need to delay the next connection vote because the collector WILL skip fast updates (see documentation)
                     // and ignore the change since the TrafficControl object would not have changed.
                     electrumControlChanges.send { decrementDisconnectCount() }
                 }
-                previousElectrumConfig = config
+                previousElectrumConfig = newElectrumConfig
             }
         }
     }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConnectionsDaemon.kt
@@ -73,7 +73,8 @@ class AppConnectionsDaemon(
     private val httpApiControlFlow = MutableStateFlow(TrafficControl())
     private val httpApiControlChanges = Channel<TrafficControl.() -> TrafficControl>()
 
-    var lastElectrumServerAddress: ServerAddress? = null
+    private var _lastElectrumServerAddress = MutableStateFlow<ServerAddress?>(null)
+    val lastElectrumServerAddress: StateFlow<ServerAddress?> = _lastElectrumServerAddress
 
     init {
         fun enableControlFlow(
@@ -109,7 +110,7 @@ class AppConnectionsDaemon(
                                     logger.info { "connecting to electrum server=$electrumServerAddress" }
                                     electrumClient.connect(electrumServerAddress)
                                 }
-                                lastElectrumServerAddress = electrumServerAddress
+                                _lastElectrumServerAddress.value = electrumServerAddress
                             }
                         }
                     }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppElectrumConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppElectrumConfigurationController.kt
@@ -26,11 +26,13 @@ class AppElectrumConfigurationController(
         launch {
             combine(
                 configurationManager.electrumConfig(),
+                appConnectionsDaemon.lastElectrumServerAddress,
                 electrumClient.connectionState,
                 configurationManager.electrumMessages(),
-                transform = { configState, connectionState, message ->
+                transform = { configState, currentServer, connectionState, message ->
                     ElectrumConfiguration.Model(
                         configuration = configState,
+                        currentServer = currentServer,
                         connection = connectionState,
                         blockHeight = message?.height ?: 0,
                         tipTimestamp = message?.header?.time ?: 0,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppElectrumConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppElectrumConfigurationController.kt
@@ -3,6 +3,7 @@ package fr.acinq.phoenix.app.ctrl.config
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
 import fr.acinq.lightning.io.TcpSocket
 import fr.acinq.phoenix.app.AppConfigurationManager
+import fr.acinq.phoenix.app.AppConnectionsDaemon
 import fr.acinq.phoenix.app.ctrl.AppController
 import fr.acinq.phoenix.ctrl.config.ElectrumConfiguration
 import fr.acinq.phoenix.data.ElectrumAddress
@@ -17,7 +18,8 @@ import org.kodein.log.LoggerFactory
 class AppElectrumConfigurationController(
     loggerFactory: LoggerFactory,
     private val configurationManager: AppConfigurationManager,
-    private val electrumClient: ElectrumClient
+    private val electrumClient: ElectrumClient,
+    private val appConnectionsDaemon: AppConnectionsDaemon
 ) : AppController<ElectrumConfiguration.Model, ElectrumConfiguration.Intent>(loggerFactory, ElectrumConfiguration.Model()) {
 
     init {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/config/ElectrumConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/config/ElectrumConfigurationController.kt
@@ -1,6 +1,7 @@
 package fr.acinq.phoenix.ctrl.config
 
 import fr.acinq.lightning.utils.Connection
+import fr.acinq.lightning.utils.ServerAddress
 import fr.acinq.phoenix.ctrl.MVI
 import fr.acinq.phoenix.data.ElectrumConfig
 
@@ -10,6 +11,7 @@ object ElectrumConfiguration {
 
     data class Model(
         val configuration: ElectrumConfig? = null,
+    //  val currentServer: ServerAddress? = null,
         val connection: Connection = Connection.CLOSED,
         val feeRate: Long = 0,
         val blockHeight: Int = 0,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/config/ElectrumConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/ctrl/config/ElectrumConfigurationController.kt
@@ -11,7 +11,7 @@ object ElectrumConfiguration {
 
     data class Model(
         val configuration: ElectrumConfig? = null,
-    //  val currentServer: ServerAddress? = null,
+        val currentServer: ServerAddress? = null,
         val connection: Connection = Connection.CLOSED,
         val feeRate: Long = 0,
         val blockHeight: Int = 0,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
@@ -65,7 +65,6 @@ enum class FiatCurrency : CurrencyUnit {
 }
 
 sealed class ElectrumConfig {
-    abstract val server: ServerAddress
-    data class Random(override val server: ServerAddress) : ElectrumConfig()
-    data class Custom(override val server: ServerAddress) : ElectrumConfig()
+    data class Custom(val server: ServerAddress) : ElectrumConfig()
+    object Random : ElectrumConfig()
 }


### PR DESCRIPTION
The previous code selected a random electrum server on app launch. If we experienced problems connecting to that server, then the app would be unable to connect at all. And the only fix was to force-quit the app (and hope a different server was selected next time).

With this change, a random electrum server is selected on each connection attempt.