### PR TITLE
Show channel balance, even when offline.

### DIFF
--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -64,7 +64,7 @@ kotlin {
 
     sourceSets {
 
-        val lightningkmpVersion = "1.0-beta12"
+        val lightningkmpVersion = "snapshot"
         val coroutinesVersion = "1.4.2-native-mt"
         val serializationVersion = "1.1.0"
         val secp256k1Version = "0.4.1"

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppHomeController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppHomeController.kt
@@ -1,11 +1,8 @@
 package fr.acinq.phoenix.app.ctrl
 
+import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.MilliSatoshi
-import fr.acinq.lightning.channel.Aborted
-import fr.acinq.lightning.channel.Closed
-import fr.acinq.lightning.channel.Closing
-import fr.acinq.lightning.channel.ErrorInformationLeak
-import fr.acinq.lightning.db.WalletPayment
+import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.utils.sum
 import fr.acinq.phoenix.app.PaymentsManager
 import fr.acinq.phoenix.app.PeerManager
@@ -13,6 +10,8 @@ import fr.acinq.phoenix.ctrl.Home
 import fr.acinq.phoenix.utils.localCommitmentSpec
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.kodein.log.LoggerFactory
 
@@ -26,21 +25,27 @@ class AppHomeController(
     loggerFactory,
     firstModel = Home.emptyModel
 ) {
+    private var normalChannelsReady = false
 
     init {
         launch {
+            // Fetch initial "boot" balance.
+            // This allows us to show the user his/her balance before the connection is up.
+            val bootChannels = peerManager.getPeer().bootChannelsFlow.filterNotNull().first()
+            if (!normalChannelsReady) {
+                updateBalance(bootChannels)
+            }
+        }
+        launch {
             peerManager.getPeer().channelsFlow.collect { channels ->
-                val newBalance = channels.values.map {
-                    when (it) {
-                        is Closing -> MilliSatoshi(0)
-                        is Closed -> MilliSatoshi(0)
-                        is Aborted -> MilliSatoshi(0)
-                        is ErrorInformationLeak -> MilliSatoshi(0)
-                        else -> it.localCommitmentSpec?.toLocal ?: MilliSatoshi(0)
-                    }
-                }.sum()
-
-                model { copy(balance = newBalance) }
+                // On boot, this fires with an empty channels map.
+                // We want to ignore this false information.
+                if (!normalChannelsReady && channels.size > 0) {
+                    normalChannelsReady = true
+                }
+                if (normalChannelsReady) {
+                    updateBalance(channels)
+                }
             }
         }
 
@@ -57,6 +62,28 @@ class AppHomeController(
                 }
             }
         }
+    }
+
+    private suspend fun updateBalance(channels: Map<ByteVector32, ChannelState>): Unit {
+        val newBalance = channels.values.map {
+            // If the channel is offline, we want to display the underlying balance.
+            // The alternative is to display a zero balance whenever the user is offline.
+            // And if there's one sure way to make user's freak out,
+            // it's showing them a zero balance...
+            val channel = when (it) {
+                is Offline -> it.state
+                else -> it
+            }
+            when (channel) {
+                is Closing -> MilliSatoshi(0)
+                is Closed -> MilliSatoshi(0)
+                is Aborted -> MilliSatoshi(0)
+                is ErrorInformationLeak -> MilliSatoshi(0)
+                else -> it.localCommitmentSpec?.toLocal ?: MilliSatoshi(0)
+            }
+        }.sum()
+
+        model { copy(balance = newBalance) }
     }
 
     override fun process(intent: Home.Intent) {}


### PR DESCRIPTION
Fixes: issue #168 - Show balance/channels at startup even when the wallet has not finished channel reestablish

Depends on: https://github.com/ACINQ/lightning-kmp/pull/266
