### PR TITLE
Accept at most 12 (6 incoming + 6 outgoing) pending HTLCs

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/NodeParamsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/NodeParamsManager.kt
@@ -94,7 +94,7 @@ class NodeParamsManager(
                         feerateTolerance = FeerateTolerance(ratioLow = 0.01, ratioHigh = 100.0)
                     ),
                     maxHtlcValueInFlightMsat = 20000000000L,
-                    maxAcceptedHtlcs = 30,
+                    maxAcceptedHtlcs = 6,
                     expiryDeltaBlocks = CltvExpiryDelta(144),
                     fulfillSafetyBeforeTimeoutBlocks = CltvExpiryDelta(6),
                     checkHtlcTimeoutAfterStartupDelaySeconds = 15,

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/TestConstants.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/TestConstants.kt
@@ -54,7 +54,7 @@ object TestConstants {
             feerateTolerance = FeerateTolerance(ratioLow = 0.01, ratioHigh = 100.0)
         ),
         maxHtlcValueInFlightMsat = 150000000L,
-        maxAcceptedHtlcs = 30,
+        maxAcceptedHtlcs = 6,
         expiryDeltaBlocks = CltvExpiryDelta(144),
         fulfillSafetyBeforeTimeoutBlocks = CltvExpiryDelta(6),
         checkHtlcTimeoutAfterStartupDelaySeconds = 15,


### PR DESCRIPTION
Since https://github.com/ACINQ/lightning-kmp/pull/268 has been merged, we also check the number of outgoing HTLCs against
our own setting (and not just our peer's). 6 is safe to use with encrypted peer backups (with at most 6 incoming and 6
outgoing payments LN messages that include a backup will remain below 65 Kb).