### PR TITLE
Streamline optional Android build and centralize dependencies versions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -5,9 +5,10 @@ It can run on many different platforms, including mobile devices (iOS and Androi
 
 ## Requirements
 
-You will need to install the Large File Storage Git extension: https://git-lfs.github.com/.
-
-For iOS, you need [Intellij IDEA Community edition](https://www.jetbrains.com/idea/download/) and [Xcode](https://developer.apple.com/xcode/). For Android, you only need [Android Studio Preview](https://developer.android.com/studio/preview) Canary Build.
+You'll need to install the following:
+- [Git LFS](https://git-lfs.github.com/): large files like png are stored using the Large File Storage Git extension.
+- [Xcode](https://developer.apple.com/xcode/): if you build the iOS app.
+- [Android Studio](https://developer.android.com/studio): if you want to build the Android app. It is also recommended if you want to contribute to the `phoenix-shared` module which contains shared code used by both iOS and Android apps.
 
 ## Build lightning-kmp
 
@@ -54,7 +55,7 @@ If the project builds successfully, you can then run it on a device or an emulat
 
 ### Build the Android app
 
-Open the entire phoenix-kmm project in Android Studio, then build the application. Note that the Android app uses Jetpack compose, which currently requires Android Studio Canary. Using a regular Android Studio release will not work.
+Open the entire phoenix-kmm project in Android Studio, then build the application. Note that the Android app uses Jetpack compose, which currently requires Android Studio Canary. Using a regular Android Studio release may cause issues.
 
 ## Troubleshooting
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
         classpath("com.android.tools.build:gradle:4.2.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
         classpath("org.jetbrains.kotlin:kotlin-serialization:${Versions.kotlin}")
-        classpath("com.squareup.sqldelight:gradle-plugin:1.4.4")
+        classpath("com.squareup.sqldelight:gradle-plugin:${Versions.sqlDelight}")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,15 +5,9 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
-
-//        val isIntelliJ = System.getProperty("isIntelliJ")!!.toBoolean()
-//        val androidVersion = if (isIntelliJ) "4.0.1" else "7.1.0-alpha01"
-//        val androidVersion = "7.1.0-alpha01"
-//        classpath("com.android.tools.build:gradle:$androidVersion")
         classpath("com.android.tools.build:gradle:4.2.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
-        classpath("org.jetbrains.kotlin:kotlin-serialization:1.4.32")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
+        classpath("org.jetbrains.kotlin:kotlin-serialization:${Versions.kotlin}")
         classpath("com.squareup.sqldelight:gradle-plugin:1.4.4")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,32 +1,28 @@
 buildscript {
-    val kotlin_version by extra("1.4.31")
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
 
-        val isIntelliJ = System.getProperty("isIntelliJ")!!.toBoolean()
-        val androidVersion = if (isIntelliJ) "4.0.1" else "7.0.0-alpha09"
-        classpath("com.android.tools.build:gradle:$androidVersion")
-
-        val sqldelightVersion = "1.4.4"
-        classpath("com.squareup.sqldelight:gradle-plugin:$sqldelightVersion")
+//        val isIntelliJ = System.getProperty("isIntelliJ")!!.toBoolean()
+//        val androidVersion = if (isIntelliJ) "4.0.1" else "7.1.0-alpha01"
+//        val androidVersion = "7.1.0-alpha01"
+//        classpath("com.android.tools.build:gradle:$androidVersion")
+        classpath("com.android.tools.build:gradle:4.2.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
+        classpath("org.jetbrains.kotlin:kotlin-serialization:1.4.32")
+        classpath("com.squareup.sqldelight:gradle-plugin:1.4.4")
     }
 }
 
 allprojects {
     repositories {
         mavenLocal()
-        maven("https://dl.bintray.com/acinq/libs")
-        maven("https://dl.bintray.com/kotlin/ktor")
-        maven("https://kotlin.bintray.com/kotlinx")
-        maven("https://dl.bintray.com/kodein-framework/Kodein-DB")
-        maven("https://dl.bintray.com/kodein-framework/Kodein-Memory")
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,6 @@
+repositories {
+    jcenter()
+}
+plugins {
+    `kotlin-dsl`
+}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,29 @@
+object Versions {
+    const val lightningKmp = "snapshot"
+    const val secp256k1 = "0.5.1"
+
+    const val kotlin = "1.4.32"
+    const val coroutines = "1.4.3-native-mt"
+    const val serialization = "1.1.0"
+    const val datetime = "0.1.1"
+
+    const val ktor = "1.5.3"
+    const val sqlDelight = "1.4.4"
+    const val kodeinMemory = "0.8.0"
+
+    const val slf4j = "1.7.30"
+    const val junit = "4.13"
+
+    object Android {
+        const val ktx = "1.5.0"
+        const val lifecycle = "2.3.1"
+        const val prefs = "1.1.1"
+        const val compose = "1.0.0-beta07"
+        const val navCompose = "2.4.0-alpha01"
+        const val constraintLayout = "1.0.0-alpha07"
+        const val zxing = "4.1.0"
+        const val logback = "2.0.0"
+        const val testRunner = "1.3.0"
+        const val espresso = "3.3.0"
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/phoenix-android/build.gradle.kts
+++ b/phoenix-android/build.gradle.kts
@@ -3,8 +3,6 @@
 plugins {
     id("com.android.application")
     kotlin("android")
-//    id("kotlin-android")
-//    id("org.jetbrains.kotlin.android") version "1.4.32"
 }
 
 val chain: String by project
@@ -64,8 +62,8 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion = "1.4.32"
-        kotlinCompilerExtensionVersion = composeVersion
+        kotlinCompilerVersion = Versions.kotlin
+        kotlinCompilerExtensionVersion = Versions.Android.compose
     }
 
 }
@@ -83,36 +81,36 @@ dependencies {
     implementation("com.google.android.material:material:1.3.0")
 
     // -- AndroidX
-    implementation("androidx.core:core-ktx:$xCoreKtxVersion")
+    implementation("androidx.core:core-ktx:${Versions.Android.ktx}")
 //    implementation("androidx.appcompat:appcompat:1.2.0")
     // -- AndroidX: preferences
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:$xLifecycleVersion")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:$xLifecycleVersion")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.Android.lifecycle}")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:${Versions.Android.lifecycle}")
     // -- AndroidX: preferences
-    implementation("androidx.preference:preference-ktx:$xPrefsVersion")
+    implementation("androidx.preference:preference-ktx:${Versions.Android.prefs}")
 
     // -- jetpack compose
-    implementation("androidx.compose.ui:ui:$composeVersion")
-    implementation("androidx.compose.foundation:foundation:$composeVersion")
-    implementation("androidx.compose.foundation:foundation-layout:$composeVersion")
-    implementation("androidx.compose.ui:ui-tooling:$composeVersion")
-    implementation("androidx.compose.ui:ui-viewbinding:$composeVersion")
-    implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
-    implementation("androidx.compose.material:material:$composeVersion")
-    implementation("androidx.constraintlayout:constraintlayout-compose:1.0.0-alpha07")
+    implementation("androidx.compose.ui:ui:${Versions.Android.compose}")
+    implementation("androidx.compose.foundation:foundation:${Versions.Android.compose}")
+    implementation("androidx.compose.foundation:foundation-layout:${Versions.Android.compose}")
+    implementation("androidx.compose.ui:ui-tooling:${Versions.Android.compose}")
+    implementation("androidx.compose.ui:ui-viewbinding:${Versions.Android.compose}")
+    implementation("androidx.compose.runtime:runtime-livedata:${Versions.Android.compose}")
+    implementation("androidx.compose.material:material:${Versions.Android.compose}")
+    implementation("androidx.constraintlayout:constraintlayout-compose:${Versions.Android.constraintLayout}")
     // -- jetpack compose: navigation
-    implementation("androidx.navigation:navigation-compose:$navComposeVersion")
+    implementation("androidx.navigation:navigation-compose:${Versions.Android.navCompose}")
 
     // -- scanner zxing
-    implementation("com.journeyapps:zxing-android-embedded:$zxingVersion")
+    implementation("com.journeyapps:zxing-android-embedded:${Versions.Android.zxing}")
 
     // logging
-    implementation("org.slf4j:slf4j-api:1.7.30")
-    implementation("com.github.tony19:logback-android:2.0.0")
+    implementation("org.slf4j:slf4j-api:${Versions.slf4j}")
+    implementation("com.github.tony19:logback-android:${Versions.Android.logback}")
 
-    testImplementation("junit:junit:4.13.2")
+    testImplementation("junit:junit:${Versions.junit}")
     androidTestImplementation("androidx.test.ext:junit:1.1.2")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:${Versions.Android.espresso}")
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 }

--- a/phoenix-android/build.gradle.kts
+++ b/phoenix-android/build.gradle.kts
@@ -1,18 +1,19 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+//import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.android.application")
     kotlin("android")
-    id("kotlin-android")
+//    id("kotlin-android")
+//    id("org.jetbrains.kotlin.android") version "1.4.32"
 }
 
 val chain: String by project
 
-val xCoreKtxVersion = "1.3.2"
-val xLifecycleVersion = "2.3.0"
+val xCoreKtxVersion = "1.5.0"
+val xLifecycleVersion = "2.3.1"
 val xPrefsVersion = "1.1.1"
-val composeVersion = "1.0.0-beta02"
-val navComposeVersion = "1.0.0-alpha09"
+val composeVersion = "1.0.0-beta07"
+val navComposeVersion = "2.4.0-alpha01"
 val zxingVersion = "4.1.0"
 
 android {
@@ -27,12 +28,12 @@ android {
     }
 
     buildTypes {
-        debug {
+        getByName("debug") {
             resValue("string", "CHAIN", chain)
             buildConfigField("String", "CHAIN", chain)
             isDebuggable = true
         }
-        release {
+        getByName("release") {
             resValue("string", "CHAIN", chain)
             buildConfigField("String", "CHAIN", chain)
             isMinifyEnabled = false
@@ -63,7 +64,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion = "1.4.31"
+        kotlinCompilerVersion = "1.4.32"
         kotlinCompilerExtensionVersion = composeVersion
     }
 
@@ -94,12 +95,11 @@ dependencies {
     implementation("androidx.compose.ui:ui:$composeVersion")
     implementation("androidx.compose.foundation:foundation:$composeVersion")
     implementation("androidx.compose.foundation:foundation-layout:$composeVersion")
-    implementation("androidx.constraintlayout:constraintlayout-compose:1.0.0-alpha03")
     implementation("androidx.compose.ui:ui-tooling:$composeVersion")
     implementation("androidx.compose.ui:ui-viewbinding:$composeVersion")
     implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
     implementation("androidx.compose.material:material:$composeVersion")
-    implementation("androidx.compose.material:material:$composeVersion")
+    implementation("androidx.constraintlayout:constraintlayout-compose:1.0.0-alpha07")
     // -- jetpack compose: navigation
     implementation("androidx.navigation:navigation-compose:$navComposeVersion")
 
@@ -110,7 +110,7 @@ dependencies {
     implementation("org.slf4j:slf4j-api:1.7.30")
     implementation("com.github.tony19:logback-android:2.0.0")
 
-    testImplementation("junit:junit:4.13.1")
+    testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
 

--- a/phoenix-android/build.gradle.kts
+++ b/phoenix-android/build.gradle.kts
@@ -1,18 +1,9 @@
-//import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     id("com.android.application")
     kotlin("android")
 }
 
 val chain: String by project
-
-val xCoreKtxVersion = "1.5.0"
-val xLifecycleVersion = "2.3.1"
-val xPrefsVersion = "1.1.1"
-val composeVersion = "1.0.0-beta07"
-val navComposeVersion = "2.4.0-alpha01"
-val zxingVersion = "4.1.0"
 
 android {
     compileSdkVersion(30)
@@ -82,7 +73,6 @@ dependencies {
 
     // -- AndroidX
     implementation("androidx.core:core-ktx:${Versions.Android.ktx}")
-//    implementation("androidx.appcompat:appcompat:1.2.0")
     // -- AndroidX: preferences
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.Android.lifecycle}")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:${Versions.Android.lifecycle}")

--- a/phoenix-android/src/main/java/fr/acinq/phoenix/android/Navigation.kt
+++ b/phoenix-android/src/main/java/fr/acinq/phoenix/android/Navigation.kt
@@ -22,9 +22,9 @@ import androidx.compose.runtime.getValue
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
-import androidx.navigation.compose.KEY_ROUTE
+//import androidx.navigation.compose.KEY_ROUTE
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.navigate
+//import androidx.navigation.compose.navigate
 import fr.acinq.phoenix.android.security.KeyState
 import fr.acinq.phoenix.android.utils.logger
 import org.kodein.log.LoggerFactory
@@ -62,12 +62,6 @@ fun requireWalletPresent(
         logger().debug { "access to screen=$inScreen granted" }
         children()
     }
-}
-
-@Composable
-fun currentRoute(): String? {
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
-    return navBackStackEntry?.arguments?.getString(KEY_ROUTE)
 }
 
 fun NavHostController.navigate(screen: Screen, arg: String? = null, builder: NavOptionsBuilder.() -> Unit = {}) {

--- a/phoenix-android/src/main/java/fr/acinq/phoenix/android/Navigation.kt
+++ b/phoenix-android/src/main/java/fr/acinq/phoenix/android/Navigation.kt
@@ -18,13 +18,9 @@ package fr.acinq.phoenix.android
 
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
-//import androidx.navigation.compose.KEY_ROUTE
-import androidx.navigation.compose.currentBackStackEntryAsState
-//import androidx.navigation.compose.navigate
 import fr.acinq.phoenix.android.security.KeyState
 import fr.acinq.phoenix.android.utils.logger
 import org.kodein.log.LoggerFactory

--- a/phoenix-android/src/main/java/fr/acinq/phoenix/android/settings/ElectrumView.kt
+++ b/phoenix-android/src/main/java/fr/acinq/phoenix/android/settings/ElectrumView.kt
@@ -69,7 +69,8 @@ fun ElectrumView() {
                 connection == Connection.CLOSED && config is ElectrumConfig.Custom -> stringResource(id = R.string.electrum_not_connected_to_custom, config.server.host)
                 connection == Connection.ESTABLISHING && config is ElectrumConfig.Random -> stringResource(id = R.string.electrum_connecting)
                 connection == Connection.ESTABLISHING && config is ElectrumConfig.Custom -> stringResource(id = R.string.electrum_connecting_to_custom, config.server.host)
-                connection == Connection.ESTABLISHED && config != null -> stringResource(id = R.string.electrum_connected, config.server.host)
+                connection == Connection.ESTABLISHED && config is ElectrumConfig.Custom -> stringResource(id = R.string.electrum_connected, config.server.host)
+                connection == Connection.ESTABLISHED -> stringResource(id = R.string.electrum_connected, "TODO") // FIXME get server's address
                 else -> stringResource(id = R.string.electrum_not_connected)
             }
             val description = when (config) {

--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -1,88 +1,44 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-//    val withAndroid = System.getProperty("withAndroid")!!.toBoolean()
-//    if (withAndroid) id("com.android.library")
     kotlin("multiplatform")
     id("kotlinx-serialization")
-    id("com.android.library")
-//    kotlin("plugin.serialization") version "1.4.31"
     id("com.squareup.sqldelight")
+    if (System.getProperty("includeAndroid")?.toBoolean() == true) {
+        id("com.android.library")
+    }
 }
 
-val currentOs = org.gradle.internal.os.OperatingSystem.current()
+val includeAndroid = System.getProperty("includeAndroid")?.toBoolean() ?: false
+if (includeAndroid) {
+    extensions.configure<com.android.build.gradle.LibraryExtension>("android") {
+        compileSdkVersion(30)
+        defaultConfig {
+            minSdkVersion(24)
+            targetSdkVersion(30)
+        }
 
-//val withAndroid = System.getProperty("withAndroid")?.toBoolean() ?: true
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
 
-android {
-    compileSdkVersion(30)
-    defaultConfig {
-        minSdkVersion(24)
-        targetSdkVersion(30)
+        testOptions {
+            unitTests.isReturnDefaultValues = true
+        }
+
+        sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-
-    // workaround for https://youtrack.jetbrains.com/issue/KT-43944
-//    configurations {
-////        create("androidTestApi")
-//        create("androidTestDebugApi")
-//        create("androidTestReleaseApi")
-//        create("testApi")
-//        create("testDebugApi")
-//        create("testReleaseApi")
-//    }
 }
-
-//if (withAndroid) {
-//    // The `android` extension function is not in classpath if android plugin is not applied
-//    extensions.configure<com.android.build.gradle.LibraryExtension>("android") {
-//        compileSdkVersion(30)
-//        defaultConfig {
-//            minSdkVersion(24)
-//            targetSdkVersion(30)
-//        }
-//
-//        compileOptions {
-//            sourceCompatibility = JavaVersion.VERSION_1_8
-//            targetCompatibility = JavaVersion.VERSION_1_8
-//        }
-//
-//        testOptions {
-//            unitTests.isReturnDefaultValues = true
-//        }
-//
-//        sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-//
-//        // workaround for https://youtrack.jetbrains.com/issue/KT-43944
-//        configurations {
-//            create("androidTestApi")
-//            create("androidTestDebugApi")
-//            create("androidTestReleaseApi")
-//            create("testApi")
-//            create("testDebugApi")
-//            create("testReleaseApi")
-//        }
-//    }
-//}
 
 kotlin {
-//    if (withAndroid) {
-    android {
-        compilations.all {
-            kotlinOptions.jvmTarget = "1.8"
+    if (includeAndroid) {
+        android {
+            compilations.all {
+                kotlinOptions.jvmTarget = "1.8"
+            }
         }
     }
-//    }
 
     ios {
         binaries {
@@ -107,18 +63,18 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                api("fr.acinq.lightning:lightning-kmp:$lightningkmpVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
-                api("org.kodein.memory:kodein-memory-files:$kodeinMemory")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.1.1")
-                implementation("io.ktor:ktor-client-core:$ktorVersion")
-                implementation("io.ktor:ktor-client-json:$ktorVersion")
-                implementation("io.ktor:ktor-client-serialization:$ktorVersion")
-                implementation("com.squareup.sqldelight:runtime:$sqldelightVersion")
-                implementation("com.squareup.sqldelight:coroutines-extensions:$sqldelightVersion")
+                api("fr.acinq.lightning:lightning-kmp:${Versions.lightningKmp}")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:${Versions.serialization}")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:${Versions.serialization}")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.serialization}")
+                api("org.kodein.memory:kodein-memory-files:${Versions.kodeinMemory}")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:${Versions.datetime}")
+                implementation("io.ktor:ktor-client-core:${Versions.ktor}")
+                implementation("io.ktor:ktor-client-json:${Versions.ktor}")
+                implementation("io.ktor:ktor-client-serialization:${Versions.ktor}")
+                implementation("com.squareup.sqldelight:runtime:${Versions.sqlDelight}")
+                implementation("com.squareup.sqldelight:coroutines-extensions:${Versions.sqlDelight}")
             }
         }
 
@@ -129,16 +85,16 @@ kotlin {
             }
         }
 
-//        if (withAndroid) {
+        if (includeAndroid) {
             val androidMain by getting {
                 dependencies {
-                    api("androidx.core:core-ktx:1.5.0")
-                    api("fr.acinq.secp256k1:secp256k1-kmp-jni-android:$secp256k1Version")
-                    implementation("io.ktor:ktor-network:$ktorVersion")
-                    implementation("io.ktor:ktor-network-tls:$ktorVersion")
-                    implementation("io.ktor:ktor-client-android:$ktorVersion")
-                    api("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
-                    implementation("com.squareup.sqldelight:android-driver:$sqldelightVersion")
+                    api("androidx.core:core-ktx:${Versions.Android.ktx}")
+                    api("fr.acinq.secp256k1:secp256k1-kmp-jni-android:${Versions.secp256k1}")
+                    implementation("io.ktor:ktor-network:${Versions.ktor}")
+                    implementation("io.ktor:ktor-network-tls:${Versions.ktor}")
+                    implementation("io.ktor:ktor-client-android:${Versions.ktor}")
+                    api("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}")
+                    implementation("com.squareup.sqldelight:android-driver:${Versions.sqlDelight}")
                 }
             }
             val androidTest by getting {
@@ -146,29 +102,30 @@ kotlin {
                     implementation(kotlin("test-junit"))
                     implementation("androidx.test.ext:junit:1.1.2")
                     implementation("androidx.test.espresso:espresso-core:3.3.0")
-                    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+                    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}")
+                    val currentOs = org.gradle.internal.os.OperatingSystem.current()
                     val target = when {
                         currentOs.isLinux -> "linux"
                         currentOs.isMacOsX -> "darwin"
                         currentOs.isWindows -> "mingw"
                         else -> error("Unsupported OS $currentOs")
                     }
-                    implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm-$target:$secp256k1Version")
-                    implementation("com.squareup.sqldelight:sqlite-driver:$sqldelightVersion")
+                    implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm-$target:${Versions.secp256k1}")
+                    implementation("com.squareup.sqldelight:sqlite-driver:${Versions.sqlDelight}")
                 }
             }
-//        }
+        }
 
         val iosMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-ios:$ktorVersion")
-                implementation("com.squareup.sqldelight:native-driver:$sqldelightVersion")
+                implementation("io.ktor:ktor-client-ios:${Versions.ktor}")
+                implementation("com.squareup.sqldelight:native-driver:${Versions.sqlDelight}")
             }
         }
 
         val iosTest by getting {
             dependencies {
-                implementation("com.squareup.sqldelight:native-driver:$sqldelightVersion")
+                implementation("com.squareup.sqldelight:native-driver:${Versions.sqlDelight}")
             }
         }
 

--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -1,55 +1,88 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
-    val withAndroid = System.getProperty("withAndroid")!!.toBoolean()
-    if (withAndroid) id("com.android.library")
+//    val withAndroid = System.getProperty("withAndroid")!!.toBoolean()
+//    if (withAndroid) id("com.android.library")
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "1.4.31"
+    id("kotlinx-serialization")
+    id("com.android.library")
+//    kotlin("plugin.serialization") version "1.4.31"
     id("com.squareup.sqldelight")
 }
 
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
-val withAndroid = System.getProperty("withAndroid")!!.toBoolean()
+//val withAndroid = System.getProperty("withAndroid")?.toBoolean() ?: true
 
-if (withAndroid) {
-    // The `android` extension function is not in classpath if android plugin is not applied
-    extensions.configure<com.android.build.gradle.LibraryExtension>("android") {
-        compileSdkVersion(30)
-        defaultConfig {
-            minSdkVersion(24)
-            targetSdkVersion(30)
-        }
-
-        compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
-        }
-
-        testOptions {
-            unitTests.isReturnDefaultValues = true
-        }
-
-        sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-
-        // workaround for https://youtrack.jetbrains.com/issue/KT-43944
-        configurations {
-            create("androidTestApi")
-            create("androidTestDebugApi")
-            create("androidTestReleaseApi")
-            create("testApi")
-            create("testDebugApi")
-            create("testReleaseApi")
-        }
+android {
+    compileSdkVersion(30)
+    defaultConfig {
+        minSdkVersion(24)
+        targetSdkVersion(30)
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+
+    // workaround for https://youtrack.jetbrains.com/issue/KT-43944
+//    configurations {
+////        create("androidTestApi")
+//        create("androidTestDebugApi")
+//        create("androidTestReleaseApi")
+//        create("testApi")
+//        create("testDebugApi")
+//        create("testReleaseApi")
+//    }
 }
 
+//if (withAndroid) {
+//    // The `android` extension function is not in classpath if android plugin is not applied
+//    extensions.configure<com.android.build.gradle.LibraryExtension>("android") {
+//        compileSdkVersion(30)
+//        defaultConfig {
+//            minSdkVersion(24)
+//            targetSdkVersion(30)
+//        }
+//
+//        compileOptions {
+//            sourceCompatibility = JavaVersion.VERSION_1_8
+//            targetCompatibility = JavaVersion.VERSION_1_8
+//        }
+//
+//        testOptions {
+//            unitTests.isReturnDefaultValues = true
+//        }
+//
+//        sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+//
+//        // workaround for https://youtrack.jetbrains.com/issue/KT-43944
+//        configurations {
+//            create("androidTestApi")
+//            create("androidTestDebugApi")
+//            create("androidTestReleaseApi")
+//            create("testApi")
+//            create("testDebugApi")
+//            create("testReleaseApi")
+//        }
+//    }
+//}
+
 kotlin {
-    if (withAndroid) {
-        android {
-            compilations.all {
-                kotlinOptions.jvmTarget = "1.8"
-            }
+//    if (withAndroid) {
+    android {
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
         }
     }
+//    }
 
     ios {
         binaries {
@@ -65,9 +98,9 @@ kotlin {
     sourceSets {
 
         val lightningkmpVersion = "snapshot"
-        val coroutinesVersion = "1.4.2-native-mt"
+        val coroutinesVersion = "1.4.3-native-mt"
         val serializationVersion = "1.1.0"
-        val secp256k1Version = "0.4.1"
+        val secp256k1Version = "0.5.1"
         val ktorVersion = "1.5.2"
         val kodeinMemory = "0.8.0"
         val sqldelightVersion = "1.4.4"
@@ -79,9 +112,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
                 api("org.kodein.memory:kodein-memory-files:$kodeinMemory")
-                api("org.jetbrains.kotlinx:kotlinx-coroutines-core") {
-                    version { strictly(coroutinesVersion) }
-                }
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.1.1")
                 implementation("io.ktor:ktor-client-core:$ktorVersion")
                 implementation("io.ktor:ktor-client-json:$ktorVersion")
@@ -98,10 +129,10 @@ kotlin {
             }
         }
 
-        if (withAndroid) {
+//        if (withAndroid) {
             val androidMain by getting {
                 dependencies {
-                    api("androidx.core:core-ktx:1.3.2")
+                    api("androidx.core:core-ktx:1.5.0")
                     api("fr.acinq.secp256k1:secp256k1-kmp-jni-android:$secp256k1Version")
                     implementation("io.ktor:ktor-network:$ktorVersion")
                     implementation("io.ktor:ktor-network-tls:$ktorVersion")
@@ -120,13 +151,13 @@ kotlin {
                         currentOs.isLinux -> "linux"
                         currentOs.isMacOsX -> "darwin"
                         currentOs.isWindows -> "mingw"
-                        else -> error("UnsupportedmOS $currentOs")
+                        else -> error("Unsupported OS $currentOs")
                     }
                     implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm-$target:$secp256k1Version")
                     implementation("com.squareup.sqldelight:sqlite-driver:$sqldelightVersion")
                 }
             }
-        }
+//        }
 
         val iosMain by getting {
             dependencies {
@@ -171,7 +202,7 @@ val packForXcode by tasks.creating(Sync::class) {
         "iphoneos" -> "iosArm64"
         else -> error("Unknown XCode platform $platformName")
     }
-    val framework = kotlin.targets.getByName<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>(targetName).binaries.getFramework(mode)
+    val framework = kotlin.targets.getByName<KotlinNativeTarget>(targetName).binaries.getFramework(mode)
     inputs.property("mode", mode)
     dependsOn(framework.linkTask)
     from({ framework.outputDirectory })
@@ -180,7 +211,7 @@ val packForXcode by tasks.creating(Sync::class) {
 tasks.getByName("build").dependsOn(packForXcode)
 
 afterEvaluate {
-    tasks.withType<AbstractTestTask>() {
+    tasks.withType<AbstractTestTask> {
         testLogging {
             events("passed", "skipped", "failed", "standard_out", "standard_error")
             showExceptions = true

--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -52,15 +52,6 @@ kotlin {
     }
 
     sourceSets {
-
-        val lightningkmpVersion = "snapshot"
-        val coroutinesVersion = "1.4.3-native-mt"
-        val serializationVersion = "1.1.0"
-        val secp256k1Version = "0.5.1"
-        val ktorVersion = "1.5.2"
-        val kodeinMemory = "0.8.0"
-        val sqldelightVersion = "1.4.4"
-
         val commonMain by getting {
             dependencies {
                 api("fr.acinq.lightning:lightning-kmp:${Versions.lightningKmp}")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,37 +1,47 @@
-enableFeaturePreview("GRADLE_METADATA")
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        maven(url = "https://maven.pkg.jetbrains.space/public/p/compose/dev")
+    }
+}
+
 rootProject.name = "phoenix-kmm"
 
+enableFeaturePreview("GRADLE_METADATA")
+
 include(":phoenix-shared")
+include(":phoenix-android")
 
 
-val isIntelliJ = System.getProperty("idea.paths.selector").orEmpty().startsWith("IntelliJIdea")
+//val isIntelliJ = System.getProperty("idea.paths.selector").orEmpty().startsWith("IntelliJIdea")
 
-// We cannot use buildSrc here for now.
-// https://github.com/gradle/gradle/issues/11090#issuecomment-734795353
-
-val skipAndroid: String? by settings
-
-val withAndroid = if (skipAndroid == "true") {
-    false
-} else {
-    val localFile = File("$rootDir/local.properties").takeIf { it.exists() }
-        ?: error("Please create a $rootDir/local.properties file with either 'sdk.dir' or 'skip.android' properties")
-
-    val localProperties = java.util.Properties()
-    localFile.inputStream().use { localProperties.load(it) }
-
-    if (localProperties["sdk.dir"] == null && localProperties["skip.android"] != "true") {
-        error("local.properties: sdk.dir == null && skip.android != true : $localProperties")
-    }
-
-    localProperties["skip.android"] != "true"
-}
-
-System.setProperty("fr.acinq.phoenix.with-android", if (withAndroid) "true" else "false")
-
-if (withAndroid && !isIntelliJ) {
-    include(":phoenix-android")
-}
-
-System.setProperty("withAndroid", withAndroid.toString())
-System.setProperty("isIntelliJ", isIntelliJ.toString())
+//// We cannot use buildSrc here for now.
+//// https://github.com/gradle/gradle/issues/11090#issuecomment-734795353
+//
+//val skipAndroid: String? by settings
+//
+//val withAndroid = if (skipAndroid == "true") {
+//    false
+//} else {
+//    val localFile = File("$rootDir/local.properties").takeIf { it.exists() }
+//        ?: error("Please create a $rootDir/local.properties file with either 'sdk.dir' or 'skip.android' properties")
+//
+//    val localProperties = java.util.Properties()
+//    localFile.inputStream().use { localProperties.load(it) }
+//
+//    if (localProperties["sdk.dir"] == null && localProperties["skip.android"] != "true") {
+//        error("local.properties: sdk.dir == null && skip.android != true : $localProperties")
+//    }
+//
+//    localProperties["skip.android"] != "true"
+//}
+//
+//System.setProperty("fr.acinq.phoenix.with-android", if (withAndroid) "true" else "false")
+//
+//if (withAndroid && !isIntelliJ) {
+//    include(":phoenix-android")
+//}
+//
+//System.setProperty("withAndroid", withAndroid.toString())
+//System.setProperty("isIntelliJ", isIntelliJ.toString())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,38 +10,17 @@ rootProject.name = "phoenix-kmm"
 
 enableFeaturePreview("GRADLE_METADATA")
 
+// We use a property defined in `local.properties` to know whether we should build the android application or not.
+// For example, iOS developers may want to skip that most of the time.
+val skipAndroid = File("$rootDir/local.properties").takeIf { it.exists() }
+    ?.inputStream()?.use { java.util.Properties().apply { load(it) } }
+    ?.run { getProperty("skip.android", "true")?.toBoolean() }
+    ?: true
+
+// Use system properties to inject the property in other gradle build files.
+System.setProperty("includeAndroid", (!skipAndroid).toString())
+
 include(":phoenix-shared")
-include(":phoenix-android")
-
-
-//val isIntelliJ = System.getProperty("idea.paths.selector").orEmpty().startsWith("IntelliJIdea")
-
-//// We cannot use buildSrc here for now.
-//// https://github.com/gradle/gradle/issues/11090#issuecomment-734795353
-//
-//val skipAndroid: String? by settings
-//
-//val withAndroid = if (skipAndroid == "true") {
-//    false
-//} else {
-//    val localFile = File("$rootDir/local.properties").takeIf { it.exists() }
-//        ?: error("Please create a $rootDir/local.properties file with either 'sdk.dir' or 'skip.android' properties")
-//
-//    val localProperties = java.util.Properties()
-//    localFile.inputStream().use { localProperties.load(it) }
-//
-//    if (localProperties["sdk.dir"] == null && localProperties["skip.android"] != "true") {
-//        error("local.properties: sdk.dir == null && skip.android != true : $localProperties")
-//    }
-//
-//    localProperties["skip.android"] != "true"
-//}
-//
-//System.setProperty("fr.acinq.phoenix.with-android", if (withAndroid) "true" else "false")
-//
-//if (withAndroid && !isIntelliJ) {
-//    include(":phoenix-android")
-//}
-//
-//System.setProperty("withAndroid", withAndroid.toString())
-//System.setProperty("isIntelliJ", isIntelliJ.toString())
+if (!skipAndroid) {
+    include(":phoenix-android")
+}


### PR DESCRIPTION
This PR fixes compilation issues in the android app, simplifies the optional android build logic a little, and centralizes the versions of the project's dependencies in a `Version.kt` file in `buildSrc`.

We now assume that Android Studio is used for development in the `phoenix-shared` module (not IntelliJ).