### PR TITLE
Improved rounding (for both fiat & bitcoin amounts)

### DIFF
--- a/phoenix-ios/phoenix-ios/utils/FormattedAmount.swift
+++ b/phoenix-ios/phoenix-ios/utils/FormattedAmount.swift
@@ -62,6 +62,14 @@ struct FormattedAmount {
 		let range = sRange.upperBound ..< digits.endIndex
 		return String(digits[range])
 	}
+	
+	/// Returns whether or not the amount contains any fractional digits. E.g.:
+	/// - digits="12,845"   => false
+	/// - digits="12 845.1" => true
+	///
+	var hasFractionDigits: Bool {
+		return !fractionDigits.isEmpty
+	}
 }
 
 extension FormattedAmount {

--- a/phoenix-ios/phoenix-ios/views/PaymentView.swift
+++ b/phoenix-ios/phoenix-ios/views/PaymentView.swift
@@ -175,17 +175,46 @@ fileprivate struct SummaryView: View {
 				EmptyView()
 			}
 
-			HStack(alignment: .bottom) {
+			HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
 				let amount = Utils.format(currencyPrefs, msat: payment.amountMsat(), hideMsats: false)
 
-				Text(amount.digits)
-					.font(.largeTitle)
-					.onTapGesture { toggleCurrencyType() }
-				Text(amount.type)
-					.font(.title3)
-					.foregroundColor(Color.appAccent)
-					.padding(.bottom, 4)
-					.onTapGesture { toggleCurrencyType() }
+				if currencyPrefs.currencyType == .bitcoin &&
+				   currencyPrefs.bitcoinUnit == .sat &&
+				   amount.hasFractionDigits
+				{
+					// We're showing the value in satoshis, but the value contains a fractional
+					// component representing the millisatoshis.
+					// This can be a little confusing for those new to Lightning.
+					// So we're going to downplay the millisatoshis visually.
+					
+					Text("\(amount.integerDigits).")
+						.font(.largeTitle)
+						.onTapGesture { toggleCurrencyType() }
+					Text(amount.fractionDigits)
+						.lineLimit(1)            // SwiftUI bugs
+						.minimumScaleFactor(0.5) // Truncating text
+						.font(.title)
+						.foregroundColor(Color.secondary)
+						.onTapGesture { toggleCurrencyType() }
+						.padding(.trailing, 6)
+					Text(amount.type)
+						.font(.title3)
+						.foregroundColor(Color.appAccent)
+						.padding(.bottom, 4)
+						.onTapGesture { toggleCurrencyType() }
+					
+				} else {
+					
+					Text(amount.digits)
+						.font(.largeTitle)
+						.onTapGesture { toggleCurrencyType() }
+						.padding(.trailing, 6)
+					Text(amount.type)
+						.font(.title3)
+						.foregroundColor(Color.appAccent)
+						.padding(.bottom, 4)
+						.onTapGesture { toggleCurrencyType() }
+				}
 			}
 			.padding([.top, .leading, .trailing], 8)
 			.padding(.bottom, 33)


### PR DESCRIPTION
I think the app has been rounding amounts in a sub-optimal way.

For example:
* -16,001 msats => rounds to => -17 sats
* -4.009 usd => rounds to => -4.00 usd

In general, I believe the "halfUp" rounding method is preferred, which rounds to the nearest value, or away from zero if equidistant:
* -16,001 msats => rounds to => -16 sats
* -4.009 usd => rounds to => -4.01 usd
* -16,500 msats => rounds to => -17 sats
* +16,500 msats => rounds to => +17 sats
* -4.005 usd => rounds to => -4.01 usd
* +4.005 usd => rounds to => +4.01 usd

But there's an edge case: ZERO :grimacing:
* -100 msats => rounds to => -0 sats
* -0.001 usd => rounds to => -0.00 usd

So this PR adds explicit handling of the zero-edge-case, and switches the rounding mode to up, which rounds away from zero :sunglasses:
* -100 msats => rounds to => -1 sats
* +100 msats => rounds to => +1 sats
* -0.001 usd => rounds to => -0.01 usd
* +0.001 usd => rounds to => +0.01 usd

The PR also tweaks the way we display millisatoshis in the Payment screen. When demoing the app recently, I've had several people ask about the millisatoshis.

> "I think you have a rounding error or something there. The satoshi is the smallest possible bitcoin unit..."

Which is really just an education problem. But it does make me think that de-emphasizing the millisatoshi values in the UI kinda makes sense.

<img width="302" alt="Screen Shot 2021-06-09 at 16 45 38" src="https://user-images.githubusercontent.com/304604/121436216-2a586400-c94e-11eb-9afa-a5ee2a0ed7d5.png">
