### PR TITLE
Allow outgoing payments to complete if app is backgrounded

### DIFF
--- a/phoenix-ios/phoenix-ios/utils/KotlinPublishers.swift
+++ b/phoenix-ios/phoenix-ios/utils/KotlinPublishers.swift
@@ -112,6 +112,19 @@ extension PaymentsManager {
 				return $0 as? Lightning_kmpIncomingPayment
 			}
 			.eraseToAnyPublisher()
+		
+		/// Transforming from Kotlin:
+		/// ```
+		/// inFlightOutgoingPayments: StateFlow<Set<UUID>>
+		/// ```
+		static var inFlightOutgoingPaymentsPublisher: AnyPublisher<Int, Never> =
+			KotlinCurrentValueSubject<NSSet, Set<Lightning_kmpUUID>>(
+				AppDelegate.get().business.paymentsManager.inFlightOutgoingPayments
+			)
+			.map {
+				return $0.count
+			}
+			.eraseToAnyPublisher()
 	}
 	
 	func paymentsPagePublisher() -> AnyPublisher<PaymentsPage, Never> {
@@ -128,6 +141,11 @@ extension PaymentsManager {
 	
 	func lastIncomingPaymentPublisher() -> AnyPublisher<Lightning_kmpIncomingPayment, Never> {
 		return _Lazy.lastIncomingPaymentPublisher
+	}
+	
+	func inFlightOutgoingPaymentsPublisher() -> AnyPublisher<Int, Never> {
+		
+		return _Lazy.inFlightOutgoingPaymentsPublisher
 	}
 }
 


### PR DESCRIPTION
Partially addresses issue #108 - adds solution for outgoing payments.

A fix for incoming payments is still needed. But I think the problem for outgoing payments is far more common. And thus a separate PR for outgoing is justified.