### PR TITLE
Use UTC timestamp for the name of the logging files

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConfigurationManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConfigurationManager.kt
@@ -40,9 +40,9 @@ class AppConfigurationManager(
     val chainContext: StateFlow<WalletContext.V0.ChainContext?> = _chainContext
 
     private fun initWalletContext() = launch {
-        val (instant, fallbackWalletContext) = appDb.getWalletContextOrNull(currentWalletContextVersion)
+        val (timestamp, fallbackWalletContext) = appDb.getWalletContextOrNull(currentWalletContextVersion)
 
-        val freshness = Clock.System.now() - instant
+        val freshness = (Clock.System.now().toEpochMilliseconds() - timestamp).milliseconds
         logger.info { "local WalletContext loaded, not updated since=$freshness" }
 
         val timeout =

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/CurrencyManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/CurrencyManager.kt
@@ -1,12 +1,15 @@
 package fr.acinq.phoenix.app
 
-import fr.acinq.phoenix.data.*
+import fr.acinq.phoenix.data.BitcoinPriceRate
+import fr.acinq.phoenix.data.BlockchainInfoPriceObject
+import fr.acinq.phoenix.data.FiatCurrency
+import fr.acinq.phoenix.data.MxnApiResponse
 import fr.acinq.phoenix.db.SqliteAppDb
 import io.ktor.client.*
 import io.ktor.client.request.*
-import kotlinx.datetime.Clock
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Clock
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import kotlin.time.ExperimentalTime

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqliteAppDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqliteAppDb.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 
 class SqliteAppDb(driver: SqlDriver) {
@@ -48,13 +47,13 @@ class SqliteAppDb(driver: SqlDriver) {
                     paramsQueries.update(
                         version = this.version,
                         data_ = rawData,
-                        updated_at = Clock.System.now().epochSeconds
+                        updated_at = Clock.System.now().toEpochMilliseconds()
                     )
                 } ?: run {
                     paramsQueries.insert(
                         version = version.name,
                         data_ = rawData,
-                        updated_at = Clock.System.now().epochSeconds
+                        updated_at = Clock.System.now().toEpochMilliseconds()
                     )
                 }
             }
@@ -63,16 +62,16 @@ class SqliteAppDb(driver: SqlDriver) {
         return getWalletContextOrNull(version).second
     }
 
-    suspend fun getWalletContextOrNull(version: WalletContext.Version): Pair<Instant, WalletContext.V0?> =
+    suspend fun getWalletContextOrNull(version: WalletContext.Version): Pair<Long, WalletContext.V0?> =
         withContext(Dispatchers.Default) {
             paramsQueries.get(version.name, ::mapWalletContext).executeAsOneOrNull()
-        } ?: Instant.DISTANT_PAST to null
+        } ?: Clock.System.now().toEpochMilliseconds() to null
 
     private fun mapWalletContext(
         version: String,
         data: String,
         updated_at: Long
-    ): Pair<Instant, WalletContext.V0?> {
+    ): Pair<Long, WalletContext.V0?> {
         val walletContext = when (WalletContext.Version.valueOf(version)) {
             WalletContext.Version.V0 -> try {
                 json.decodeFromString(
@@ -84,6 +83,6 @@ class SqliteAppDb(driver: SqlDriver) {
             }
         }
 
-        return Instant.fromEpochSeconds(updated_at) to walletContext
+        return updated_at to walletContext
     }
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqliteAppDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqliteAppDb.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 
 class SqliteAppDb(driver: SqlDriver) {
@@ -65,7 +66,7 @@ class SqliteAppDb(driver: SqlDriver) {
     suspend fun getWalletContextOrNull(version: WalletContext.Version): Pair<Long, WalletContext.V0?> =
         withContext(Dispatchers.Default) {
             paramsQueries.get(version.name, ::mapWalletContext).executeAsOneOrNull()
-        } ?: Clock.System.now().toEpochMilliseconds() to null
+        } ?: Instant.DISTANT_PAST.toEpochMilliseconds() to null
 
     private fun mapWalletContext(
         version: String,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LogMemory.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LogMemory.kt
@@ -25,7 +25,7 @@ class LogMemory(val directory: Path) : LogFrontend {
 
     private var lines = ArrayList<Line>().also { it.preventFreeze() }
 
-    private fun currentDate() = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+    private fun currentDate() = Clock.System.now().toLocalDateTime(TimeZone.UTC).date
 
     val file get() = directory.resolve(toFileName(currentDate()) + ".txt")
 


### PR DESCRIPTION
This PR alongside https://github.com/ACINQ/lightning-kmp/pull/273 makes sure that kotlinx-datetime use the UTC timezone (see https://github.com/ACINQ/phoenix-kmm/issues/148).

We also streamline the timestamps in the app database which should be in milliseconds, like in the payments database.