### PR TITLE
Minor refactor & code cleanup

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConfigurationManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConfigurationManager.kt
@@ -4,6 +4,7 @@ import fr.acinq.lightning.blockchain.electrum.ElectrumClient
 import fr.acinq.lightning.blockchain.electrum.HeaderSubscriptionResponse
 import fr.acinq.lightning.io.TcpSocket
 import fr.acinq.lightning.utils.ServerAddress
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.data.*
 import fr.acinq.phoenix.db.SqliteAppDb
 import fr.acinq.phoenix.utils.RETRY_DELAY
@@ -26,6 +27,14 @@ class AppConfigurationManager(
     private val chain: Chain,
     loggerFactory: LoggerFactory
 ) : CoroutineScope by MainScope() {
+
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        chain = business.chain,
+        appDb = business.appDb,
+        httpClient = business.httpClient,
+        electrumClient = business.electrumClient
+    )
 
     private val logger = newLogger(loggerFactory)
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/AppConnectionsDaemon.kt
@@ -3,6 +3,7 @@ package fr.acinq.phoenix.app
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
 import fr.acinq.lightning.utils.Connection
 import fr.acinq.lightning.utils.ServerAddress
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.data.ElectrumConfig
 import fr.acinq.phoenix.utils.NetworkMonitor
 import fr.acinq.phoenix.utils.NetworkState
@@ -28,6 +29,16 @@ class AppConnectionsDaemon(
     private val electrumClient: ElectrumClient,
     loggerFactory: LoggerFactory,
 ) : CoroutineScope by MainScope() {
+
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        configurationManager = business.appConfigurationManager,
+        walletManager = business.walletManager,
+        peerManager = business.peerManager,
+        currencyManager = business.currencyManager,
+        monitor = business.networkMonitor,
+        electrumClient = business.electrumClient
+    )
 
     private val logger = newLogger(loggerFactory)
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/CurrencyManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/CurrencyManager.kt
@@ -1,9 +1,7 @@
 package fr.acinq.phoenix.app
 
-import fr.acinq.phoenix.data.BitcoinPriceRate
-import fr.acinq.phoenix.data.BlockchainInfoPriceObject
-import fr.acinq.phoenix.data.FiatCurrency
-import fr.acinq.phoenix.data.MxnApiResponse
+import fr.acinq.phoenix.PhoenixBusiness
+import fr.acinq.phoenix.data.*
 import fr.acinq.phoenix.db.SqliteAppDb
 import io.ktor.client.*
 import io.ktor.client.request.*
@@ -21,6 +19,12 @@ class CurrencyManager(
     private val appDb: SqliteAppDb,
     private val httpClient: HttpClient
 ) : CoroutineScope by MainScope() {
+
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        appDb = business.appDb,
+        httpClient = business.httpClient
+    )
 
     private val log = newLogger(loggerFactory)
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/DatabaseManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/DatabaseManager.kt
@@ -1,0 +1,59 @@
+package fr.acinq.phoenix.app
+
+import fr.acinq.lightning.db.ChannelsDb
+import fr.acinq.lightning.db.Databases
+import fr.acinq.lightning.db.PaymentsDb
+import fr.acinq.phoenix.PhoenixBusiness
+import fr.acinq.phoenix.data.Chain
+import fr.acinq.phoenix.db.SqliteChannelsDb
+import fr.acinq.phoenix.db.SqlitePaymentsDb
+import fr.acinq.phoenix.db.createChannelsDbDriver
+import fr.acinq.phoenix.db.createPaymentsDbDriver
+import fr.acinq.phoenix.utils.PlatformContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+import org.kodein.memory.text.toHexString
+
+class DatabaseManager(
+    loggerFactory: LoggerFactory,
+    private val ctx: PlatformContext,
+    private val chain: Chain,
+    private val nodeParamsManager: NodeParamsManager
+) : CoroutineScope by MainScope() {
+
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        ctx = business.ctx,
+        chain = business.chain,
+        nodeParamsManager = business.nodeParamsManager
+    )
+
+    private val log = newLogger(loggerFactory)
+
+    private val _databases = MutableStateFlow<Databases?>(null)
+    val databases: StateFlow<Databases?> = _databases
+
+    init {
+        launch {
+            nodeParamsManager.nodeParams.collect { nodeParams ->
+                if (nodeParams == null) return@collect
+                log.info { "nodeParams available: building databases..." }
+
+                val nodeIdHash = nodeParams.nodeId.hash160().toHexString()
+                val channelsDb = SqliteChannelsDb(createChannelsDbDriver(ctx, chain, nodeIdHash), nodeParams.copy())
+                val paymentsDb = SqlitePaymentsDb(createPaymentsDbDriver(ctx, chain, nodeIdHash))
+                log.debug { "databases object created" }
+                _databases.value = object : Databases {
+                    override val channels: ChannelsDb get() = channelsDb
+                    override val payments: PaymentsDb get() = paymentsDb
+                }
+            }
+        }
+    }
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/PeerManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/PeerManager.kt
@@ -6,6 +6,7 @@ import fr.acinq.lightning.blockchain.electrum.ElectrumWatcher
 import fr.acinq.lightning.db.Databases
 import fr.acinq.lightning.io.Peer
 import fr.acinq.lightning.io.TcpSocket
+import fr.acinq.phoenix.PhoenixBusiness
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.MainScope
@@ -21,12 +22,23 @@ import org.kodein.log.newLogger
 class PeerManager(
     loggerFactory: LoggerFactory,
     private val nodeParamsManager: NodeParamsManager,
+    private val databaseManager: DatabaseManager,
     private val configurationManager: AppConfigurationManager,
     private val tcpSocketBuilder: TcpSocket.Builder,
     private val electrumWatcher: ElectrumWatcher,
 ) : CoroutineScope by MainScope() {
 
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        nodeParamsManager = business.nodeParamsManager,
+        databaseManager = business.databaseManager,
+        configurationManager = business.appConfigurationManager,
+        tcpSocketBuilder = business.tcpSocketBuilder,
+        electrumWatcher = business.electrumWatcher
+    )
+
     private val logger = newLogger(loggerFactory)
+
     private val _peer = MutableStateFlow<Peer?>(null)
     public val peerState: StateFlow<Peer?> = _peer
 
@@ -36,7 +48,7 @@ class PeerManager(
                 nodeParams = nodeParamsManager.nodeParams.filterNotNull().first(),
                 walletParams = configurationManager.chainContext.filterNotNull().first().walletParams(),
                 watcher = electrumWatcher,
-                db = nodeParamsManager.databases.filterNotNull().first(),
+                db = databaseManager.databases.filterNotNull().first(),
                 socketBuilder = tcpSocketBuilder,
                 scope = MainScope()
             )

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/Utilities.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/Utilities.kt
@@ -2,9 +2,11 @@ package fr.acinq.phoenix.app
 
 import fr.acinq.bitcoin.*
 import fr.acinq.lightning.utils.Either
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.data.Chain
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
+import org.kodein.log.Logger
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -12,6 +14,11 @@ class Utilities(
     loggerFactory: LoggerFactory,
     private val chain: Chain
 ) : CoroutineScope by MainScope() {
+
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        chain = business.chain
+    )
 
     private val logger = newLogger(loggerFactory)
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppContentController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppContentController.kt
@@ -1,5 +1,6 @@
 package fr.acinq.phoenix.app.ctrl
 
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.app.WalletManager
 import fr.acinq.phoenix.ctrl.Content
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -8,7 +9,18 @@ import kotlinx.coroutines.launch
 import org.kodein.log.LoggerFactory
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class AppContentController(loggerFactory: LoggerFactory, private val walletManager: WalletManager) : AppController<Content.Model, Content.Intent>(loggerFactory, Content.Model.Waiting) {
+class AppContentController(
+    loggerFactory: LoggerFactory,
+    private val walletManager: WalletManager
+) : AppController<Content.Model, Content.Intent>(
+    loggerFactory = loggerFactory,
+    firstModel = Content.Model.Waiting
+) {
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        walletManager = business.walletManager
+    )
+
     init {
         launch {
             if (walletManager.wallet.value != null) {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppHomeController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppHomeController.kt
@@ -4,6 +4,7 @@ import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.utils.sum
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.app.PaymentsManager
 import fr.acinq.phoenix.app.PeerManager
 import fr.acinq.phoenix.ctrl.Home
@@ -23,9 +24,15 @@ class AppHomeController(
     private val peerManager: PeerManager,
     private val paymentsManager: PaymentsManager
 ) : AppController<Home.Model, Home.Intent>(
-    loggerFactory,
+    loggerFactory = loggerFactory,
     firstModel = Home.emptyModel
 ) {
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        peerManager = business.peerManager,
+        paymentsManager = business.paymentsManager
+    )
+
     private var isBoot = true
 
     init {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppInitController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppInitController.kt
@@ -1,7 +1,7 @@
 package fr.acinq.phoenix.app.ctrl
 
 import fr.acinq.bitcoin.MnemonicCode
-import fr.acinq.phoenix.app.WalletManager
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.ctrl.Initialization
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -10,9 +10,14 @@ import org.kodein.log.LoggerFactory
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AppInitController(
-    loggerFactory: LoggerFactory,
-    private val walletManager: WalletManager
-) : AppController<Initialization.Model, Initialization.Intent>(loggerFactory, Initialization.Model.Ready) {
+    loggerFactory: LoggerFactory
+) : AppController<Initialization.Model, Initialization.Intent>(
+    loggerFactory = loggerFactory,
+    firstModel = Initialization.Model.Ready
+) {
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory
+    )
 
     override fun process(intent: Initialization.Intent) {
         when (intent) {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppReceiveController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppReceiveController.kt
@@ -1,17 +1,14 @@
 package fr.acinq.phoenix.app.ctrl
 
 import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.lightning.MilliSatoshi
-import fr.acinq.lightning.db.WalletPayment
 import fr.acinq.lightning.io.*
 import fr.acinq.lightning.payment.PaymentRequest
 import fr.acinq.lightning.utils.secure
 import fr.acinq.lightning.wire.SwapInRequest
-import fr.acinq.lightning.wire.SwapInResponse
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.app.PeerManager
 import fr.acinq.phoenix.ctrl.Receive
 import fr.acinq.phoenix.data.Chain
-import fr.acinq.phoenix.data.toMilliSatoshi
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.consumeEach
 import org.kodein.log.LoggerFactory
@@ -19,7 +16,19 @@ import kotlin.random.Random
 
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class AppReceiveController(loggerFactory: LoggerFactory, private val chain: Chain, private val peerManager: PeerManager) : AppController<Receive.Model, Receive.Intent>(loggerFactory, Receive.Model.Awaiting) {
+class AppReceiveController(
+    loggerFactory: LoggerFactory,
+    private val chain: Chain,
+    private val peerManager: PeerManager
+) : AppController<Receive.Model, Receive.Intent>(
+    loggerFactory = loggerFactory,
+    firstModel = Receive.Model.Awaiting
+) {
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        chain = business.chain,
+        peerManager = business.peerManager
+    )
 
     private val Receive.Intent.Ask.description: String get() = desc?.takeIf { it.isNotBlank() } ?: ""
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppRestoreWalletController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/AppRestoreWalletController.kt
@@ -1,7 +1,7 @@
 package fr.acinq.phoenix.app.ctrl
 
 import fr.acinq.bitcoin.MnemonicCode
-import fr.acinq.phoenix.app.WalletManager
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.ctrl.RestoreWallet
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -11,9 +11,12 @@ import org.kodein.log.LoggerFactory
 class AppRestoreWalletController(
     loggerFactory: LoggerFactory
 ) : AppController<RestoreWallet.Model, RestoreWallet.Intent>(
-    loggerFactory,
-    RestoreWallet.Model.Ready
+    loggerFactory = loggerFactory,
+    firstModel = RestoreWallet.Model.Ready
 ) {
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory
+    )
 
     override fun process(intent: RestoreWallet.Intent) {
         when (intent) {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppChannelsConfigurationController.kt
@@ -4,6 +4,7 @@ import fr.acinq.lightning.channel.ChannelStateWithCommitments
 import fr.acinq.lightning.channel.Normal
 import fr.acinq.lightning.serialization.v1.ByteVector32KSerializer
 import fr.acinq.lightning.serialization.v1.Serialization.lightningSerializersModule
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.app.PeerManager
 import fr.acinq.phoenix.app.ctrl.AppController
 import fr.acinq.phoenix.ctrl.config.ChannelsConfiguration
@@ -19,13 +20,18 @@ import org.kodein.log.LoggerFactory
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AppChannelsConfigurationController(
-    loggerFactory: LoggerFactory, 
+    loggerFactory: LoggerFactory,
     private val peerManager: PeerManager,
     private val chain: Chain
 ) : AppController<ChannelsConfiguration.Model, ChannelsConfiguration.Intent>(
-    loggerFactory,
+    loggerFactory = loggerFactory,
     firstModel = ChannelsConfiguration.emptyModel
 ) {
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        peerManager = business.peerManager,
+        chain = business.chain
+    )
 
     private val json = Json {
         prettyPrint = true

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppCloseChannelsConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppCloseChannelsConfigurationController.kt
@@ -4,6 +4,7 @@ import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.io.WrappedChannelEvent
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.app.PeerManager
 import fr.acinq.phoenix.app.Utilities
 import fr.acinq.phoenix.app.WalletManager
@@ -24,9 +25,18 @@ class AppCloseChannelsConfigurationController(
     private val util: Utilities,
     private val isForceClose: Boolean
 ) : AppController<CloseChannelsConfiguration.Model, CloseChannelsConfiguration.Intent>(
-    loggerFactory,
-    CloseChannelsConfiguration.Model.Loading
+    loggerFactory = loggerFactory,
+    firstModel = CloseChannelsConfiguration.Model.Loading
 ) {
+    constructor(business: PhoenixBusiness, isForceClose: Boolean): this(
+        loggerFactory = business.loggerFactory,
+        peerManager = business.peerManager,
+        walletManager = business.walletManager,
+        chain = business.chain,
+        util = business.util,
+        isForceClose = isForceClose
+    )
+
     var closingChannelIds: Set<ByteVector32>? = null
 
     fun channelInfoStatus(channel: ChannelState): ChannelInfoStatus? = when (channel) {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppConfigurationController.kt
@@ -1,5 +1,6 @@
 package fr.acinq.phoenix.app.ctrl.config
 
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.app.WalletManager
 import fr.acinq.phoenix.app.ctrl.AppController
 import fr.acinq.phoenix.ctrl.config.Configuration
@@ -8,7 +9,17 @@ import kotlinx.coroutines.launch
 import org.kodein.log.LoggerFactory
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class AppConfigurationController(loggerFactory: LoggerFactory, private val walletManager: WalletManager) : AppController<Configuration.Model, Configuration.Intent>(loggerFactory, Configuration.Model.SimpleMode) {
+class AppConfigurationController(
+    loggerFactory: LoggerFactory,
+    private val walletManager: WalletManager
+) : AppController<Configuration.Model, Configuration.Intent>(
+    loggerFactory = loggerFactory,
+    firstModel = Configuration.Model.SimpleMode
+) {
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        walletManager = business.walletManager
+    )
 
     init {
         launch {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppElectrumConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppElectrumConfigurationController.kt
@@ -3,11 +3,11 @@ package fr.acinq.phoenix.app.ctrl.config
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
 import fr.acinq.lightning.io.TcpSocket
 import fr.acinq.lightning.utils.ServerAddress
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.app.AppConfigurationManager
 import fr.acinq.phoenix.app.AppConnectionsDaemon
 import fr.acinq.phoenix.app.ctrl.AppController
 import fr.acinq.phoenix.ctrl.config.ElectrumConfiguration
-import fr.acinq.phoenix.data.ElectrumAddress
 import fr.acinq.phoenix.data.InvalidElectrumAddress
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
@@ -21,7 +21,16 @@ class AppElectrumConfigurationController(
     private val configurationManager: AppConfigurationManager,
     private val electrumClient: ElectrumClient,
     private val appConnectionsDaemon: AppConnectionsDaemon
-) : AppController<ElectrumConfiguration.Model, ElectrumConfiguration.Intent>(loggerFactory, ElectrumConfiguration.Model()) {
+) : AppController<ElectrumConfiguration.Model, ElectrumConfiguration.Intent>(
+    loggerFactory = loggerFactory,
+    firstModel = ElectrumConfiguration.Model()
+) {
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        configurationManager = business.appConfigurationManager,
+        electrumClient = business.electrumClient,
+        appConnectionsDaemon = business.appConnectionsDaemon!!
+    )
 
     init {
         launch {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppLogsConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/app/ctrl/config/AppLogsConfigurationController.kt
@@ -1,5 +1,6 @@
 package fr.acinq.phoenix.app.ctrl.config
 
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.app.ctrl.AppController
 import fr.acinq.phoenix.ctrl.config.LogsConfiguration
 import fr.acinq.phoenix.utils.LogMemory
@@ -15,11 +16,19 @@ import org.kodein.memory.io.*
 import org.kodein.memory.use
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class AppLogsConfigurationController(ctx: PlatformContext, loggerFactory: LoggerFactory, logMemory: LogMemory)
-    : AppController<LogsConfiguration.Model, LogsConfiguration.Intent>(
-    loggerFactory,
-    LogsConfiguration.Model.Loading
+class AppLogsConfigurationController(
+    ctx: PlatformContext,
+    loggerFactory: LoggerFactory,
+    logMemory: LogMemory
+) : AppController<LogsConfiguration.Model, LogsConfiguration.Intent>(
+    loggerFactory = loggerFactory,
+    firstModel = LogsConfiguration.Model.Loading
 ) {
+    constructor(business: PhoenixBusiness): this(
+        ctx = business.ctx,
+        loggerFactory = business.loggerFactory,
+        logMemory = business.logMemory
+    )
 
     private val numberOfFiles = 3 // Edit for longer files
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/ConnectionsMonitor.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/ConnectionsMonitor.kt
@@ -2,6 +2,7 @@ package fr.acinq.phoenix.utils
 
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
 import fr.acinq.lightning.utils.Connection
+import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.app.PeerManager
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,7 +21,17 @@ data class Connections(
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class ConnectionsMonitor(peerManager: PeerManager, electrumClient: ElectrumClient, networkMonitor: NetworkMonitor): CoroutineScope {
+class ConnectionsMonitor(
+    peerManager: PeerManager,
+    electrumClient: ElectrumClient,
+    networkMonitor: NetworkMonitor
+): CoroutineScope {
+
+    constructor(business: PhoenixBusiness): this(
+        peerManager = business.peerManager,
+        electrumClient = business.electrumClient,
+        networkMonitor = business.networkMonitor
+    )
 
     private val job = Job()
     override val coroutineContext = MainScope().coroutineContext + job

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/IncomingPaymentDbTypeVersionTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/IncomingPaymentDbTypeVersionTest.kt
@@ -21,6 +21,8 @@ import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.payment.PaymentRequest
 import fr.acinq.lightning.utils.msat
 import fr.acinq.phoenix.db.payments.*
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test


### PR DESCRIPTION
Previously the database logic was embedded in the NodeParamsManager. This PR separates the database logic into its own DatabaseManager.

(_It seemed odd to write `business.nodeParamsManager.databaseThing`. But seems natural to write `business.databaseManager.databaseThing`._)



Also performing a bit of code cleanup. Previously, all the init routines in PhoenixBusiness looked like this:

```kotlin
private val fooManager = FooManager(loggerFactory, manager1, manager2, manager3, manager4)
```



After adding the DatabaseManager, I realized I needed to change a dozen of these to now pass the DatabaseManager instance...

However, I also noticed that all the parameters are either `public` or `internal` within the PhoenixBusiness instance. Which means we can just do this for all the initializers:

```kotlin
private val fooManager = FooManager(this)
```

And within FooManager:

```kotlin
class FooManager(
  loggerFactory: LoggerFactory,
  private val manager1: Manager1,
  private val manager2: Manager2,
  private val manager3: Manager3,
  private val manager4: Manager4
) {
  // I added this convenience constructor
  constructor(business: PhoenixBusiness): this(
    loggerFactory = business.loggerFactory,
    manager1 = business.manager1,
    manager2 = business.manager2,
    manager3 = business.manager3,
    manager4 = business.manager4
  )
}
```

