### PR TITLE
Payment hooks

### DIFF
--- a/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
+++ b/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
@@ -1,0 +1,9 @@
+package fr.acinq.phoenix.db
+
+import fr.acinq.phoenix.db.payments.CloudKitInterface
+
+actual fun didCompletePaymentRow(id: PaymentRowId, database: PaymentsDatabase): Unit {}
+
+actual fun makeCloudKitDb(database: PaymentsDatabase): CloudKitInterface? {
+    return null
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
@@ -46,9 +46,11 @@ class SqlitePaymentsDb(private val driver: SqlDriver) : PaymentsDb {
         outgoing_paymentsAdapter = Outgoing_payments.Adapter(status_typeAdapter = EnumColumnAdapter(), details_typeAdapter = EnumColumnAdapter()),
         incoming_paymentsAdapter = Incoming_payments.Adapter(origin_typeAdapter = EnumColumnAdapter(), received_with_typeAdapter = EnumColumnAdapter())
     )
-    internal val inQueries = IncomingQueries(database.incomingPaymentsQueries)
-    private val outQueries = OutgoingQueries(database.outgoingPaymentsQueries)
+    internal val inQueries = IncomingQueries(database)
+    private val outQueries = OutgoingQueries(database)
     private val aggrQueries = database.aggregatedQueriesQueries
+
+    public val cloudKitDb = makeCloudKitDb(database)
 
     override suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>) {
         withContext(Dispatchers.Default) {
@@ -248,3 +250,22 @@ data class WalletPaymentOrderRow(
         return "${id.identifier}|${createdAt}|"
     }
 }
+
+sealed class PaymentRowId {
+    data class IncomingPaymentId(val paymentHash: ByteVector32): PaymentRowId()
+    data class OutgoingPaymentId(val id: UUID): PaymentRowId()
+}
+
+/// Implement this function to execute platform specific code when a payment completes.
+/// For example, on iOS this is used to enqueue the (encrypted) payment for upload to CloudKit.
+///
+/// Important:
+///   This function is invoked inside the same transaction used to add/modify the row.
+///   This means any database operations performed in this function are atomic,
+///   with respect to the referenced row.
+///
+expect fun didCompletePaymentRow(id: PaymentRowId, database: PaymentsDatabase): Unit
+
+/// Implemented on Apple platforms with support for CloudKit.
+///
+expect fun makeCloudKitDb(database: PaymentsDatabase): CloudKitInterface?

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/CloudKitInterface.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/CloudKitInterface.kt
@@ -1,0 +1,5 @@
+package fr.acinq.phoenix.db.payments
+
+/* Cross-platform placeholder for CloudKitDb. */
+interface CloudKitInterface {
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
@@ -22,9 +22,14 @@ import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.utils.*
 import fr.acinq.phoenix.db.IncomingPaymentNotFound
+import fr.acinq.phoenix.db.PaymentRowId
+import fr.acinq.phoenix.db.PaymentsDatabase
+import fr.acinq.phoenix.db.didCompletePaymentRow
 import fracinqphoenixdb.IncomingPaymentsQueries
 
-class IncomingQueries(private val queries: IncomingPaymentsQueries) {
+class IncomingQueries(private val database: PaymentsDatabase) {
+
+    private val queries = database.incomingPaymentsQueries
 
     fun addIncomingPayment(preimage: ByteVector32, origin: IncomingPayment.Origin, createdAt: Long) {
         val (originType, originData) = origin.mapToDb()
@@ -38,9 +43,11 @@ class IncomingQueries(private val queries: IncomingPaymentsQueries) {
     }
 
     fun receivePayment(paymentHash: ByteVector32, receivedWith: Set<IncomingPayment.ReceivedWith>, receivedAt: Long) {
-        queries.transaction {
-            val existingReceivedWith: Set<IncomingPayment.ReceivedWith> = queries.get(payment_hash = paymentHash.toByteArray(), ::mapIncomingPayment)
-                .executeAsOneOrNull()?.received?.receivedWith ?: emptySet()
+        database.transaction {
+            val existingReceivedWith: Set<IncomingPayment.ReceivedWith> = queries.get(
+                payment_hash = paymentHash.toByteArray(),
+                mapper = ::mapIncomingPayment
+            ).executeAsOneOrNull()?.received?.receivedWith ?: emptySet()
             val (receivedWithType, receivedWithBlob) = (existingReceivedWith + receivedWith).mapToDb() ?: null to null
             queries.updateReceived(
                 received_at = receivedAt,
@@ -48,13 +55,19 @@ class IncomingQueries(private val queries: IncomingPaymentsQueries) {
                 received_with_blob = receivedWithBlob,
                 payment_hash = paymentHash.toByteArray()
             )
-            if (queries.changes().executeAsOne() != 1L) throw IncomingPaymentNotFound(paymentHash)
+            if (queries.changes().executeAsOne() != 1L) {
+                throw IncomingPaymentNotFound(paymentHash)
+            }
+            didCompletePaymentRow(PaymentRowId.IncomingPaymentId(paymentHash), database)
         }
     }
 
     fun updateNewChannelReceivedWithChannelId(paymentHash: ByteVector32, channelId: ByteVector32) {
-        queries.transaction {
-            val paymentInDb: IncomingPayment? = queries.get(payment_hash = paymentHash.toByteArray(), ::mapIncomingPayment).executeAsOneOrNull()
+        database.transaction {
+            val paymentInDb: IncomingPayment? = queries.get(
+                payment_hash = paymentHash.toByteArray(),
+                mapper = ::mapIncomingPayment
+            ).executeAsOneOrNull()
             val (receivedWithType, receivedWithBlob) = paymentInDb?.received?.receivedWith?.map {
                 when (it) {
                     is IncomingPayment.ReceivedWith.NewChannel -> it.copy(channelId = channelId)
@@ -67,23 +80,36 @@ class IncomingQueries(private val queries: IncomingPaymentsQueries) {
                 received_with_blob = receivedWithBlob,
                 payment_hash = paymentHash.toByteArray()
             )
-            if (queries.changes().executeAsOne() != 1L) throw IncomingPaymentNotFound(paymentHash)
+            if (queries.changes().executeAsOne() != 1L) {
+                throw IncomingPaymentNotFound(paymentHash)
+            }
+            didCompletePaymentRow(PaymentRowId.IncomingPaymentId(paymentHash), database)
         }
     }
 
-    fun addAndReceivePayment(preimage: ByteVector32, origin: IncomingPayment.Origin, receivedWith: Set<IncomingPayment.ReceivedWith>, createdAt: Long, receivedAt: Long) {
-        val (originType, originData) = origin.mapToDb()
-        val (receivedWithType, receivedWithBlob) = receivedWith.mapToDb() ?: null to null
-        queries.insertAndReceive(
-            payment_hash = Crypto.sha256(preimage).toByteVector32().toByteArray(),
-            preimage = preimage.toByteArray(),
-            origin_type = originType,
-            origin_blob = originData,
-            received_at = receivedAt,
-            received_with_type = receivedWithType,
-            received_with_blob = receivedWithBlob,
-            created_at = createdAt
-        )
+    fun addAndReceivePayment(
+        preimage: ByteVector32,
+        origin: IncomingPayment.Origin,
+        receivedWith: Set<IncomingPayment.ReceivedWith>,
+        createdAt: Long,
+        receivedAt: Long
+    ) {
+        database.transaction {
+            val paymentHash = Crypto.sha256(preimage).toByteVector32()
+            val (originType, originData) = origin.mapToDb()
+            val (receivedWithType, receivedWithBlob) = receivedWith.mapToDb() ?: null to null
+            queries.insertAndReceive(
+                payment_hash = paymentHash.toByteArray(),
+                preimage = preimage.toByteArray(),
+                origin_type = originType,
+                origin_blob = originData,
+                received_at = receivedAt,
+                received_with_type = receivedWithType,
+                received_with_blob = receivedWithBlob,
+                created_at = createdAt
+            )
+            didCompletePaymentRow(PaymentRowId.IncomingPaymentId(paymentHash), database)
+        }
     }
 
     fun getIncomingPayment(paymentHash: ByteVector32): IncomingPayment? {
@@ -114,7 +140,12 @@ class IncomingQueries(private val queries: IncomingPaymentsQueries) {
             )
         }
 
-        private fun mapIncomingReceived(amount: MilliSatoshi?, receivedAt: Long?, receivedWithTypeVersion: IncomingReceivedWithTypeVersion?, receivedWithBlob: ByteArray?): IncomingPayment.Received? {
+        private fun mapIncomingReceived(
+            amount: MilliSatoshi?,
+            receivedAt: Long?,
+            receivedWithTypeVersion: IncomingReceivedWithTypeVersion?,
+            receivedWithBlob: ByteArray?
+        ): IncomingPayment.Received? {
             return when {
                 receivedAt == null && receivedWithTypeVersion == null && receivedWithBlob == null -> null
                 receivedAt != null && receivedWithTypeVersion != null && receivedWithBlob != null -> {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
@@ -29,14 +29,19 @@ import fr.acinq.lightning.payment.OutgoingPaymentFailure
 import fr.acinq.lightning.utils.Either
 import fr.acinq.lightning.utils.UUID
 import fr.acinq.lightning.wire.FailureMessage
+import fr.acinq.phoenix.db.PaymentRowId.*
 import fr.acinq.phoenix.db.OutgoingPaymentPartNotFound
+import fr.acinq.phoenix.db.PaymentsDatabase
+import fr.acinq.phoenix.db.didCompletePaymentRow
 import fracinqphoenixdb.OutgoingPaymentsQueries
 
-class OutgoingQueries(private val queries: OutgoingPaymentsQueries) {
+class OutgoingQueries(val database: PaymentsDatabase) {
+
+    private val queries = database.outgoingPaymentsQueries
 
     fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>) {
-        if (parts.size == 0) return
-        queries.transaction {
+        if (parts.isEmpty()) return
+        database.transaction {
             parts.map {
                 queries.addOutgoingPart(
                     part_id = it.id.toString(),
@@ -54,7 +59,7 @@ class OutgoingQueries(private val queries: OutgoingPaymentsQueries) {
 
     fun addOutgoingPayment(outgoingPayment: OutgoingPayment) {
         val (detailsTypeVersion, detailsData) = outgoingPayment.details.mapToDb()
-        queries.transaction {
+        database.transaction {
             queries.addOutgoingPayment(
                 id = outgoingPayment.id.toString(),
                 recipient_amount_msat = outgoingPayment.recipientAmount.msat,
@@ -77,7 +82,7 @@ class OutgoingQueries(private val queries: OutgoingPaymentsQueries) {
     }
 
     fun completeOutgoingPayment(id: UUID, completed: OutgoingPayment.Status.Completed) {
-        queries.transaction {
+        database.transaction {
             val (statusType, statusBlob) = completed.mapToDb()
             queries.updateOutgoingPayment(
                 id = id.toString(),
@@ -85,32 +90,51 @@ class OutgoingQueries(private val queries: OutgoingPaymentsQueries) {
                 status_type = statusType,
                 status_blob = statusBlob
             )
-            if (queries.changes().executeAsOne() != 1L) throw OutgoingPaymentPartNotFound(id)
+            if (queries.changes().executeAsOne() != 1L) {
+                throw OutgoingPaymentPartNotFound(id)
+            }
+            didCompletePaymentRow(OutgoingPaymentId(id), database)
         }
     }
 
     fun updateOutgoingPart(partId: UUID, preimage: ByteVector32, completedAt: Long) {
         val (statusTypeVersion, statusData) = OutgoingPayment.Part.Status.Succeeded(preimage).mapToDb()
-        queries.transaction {
+        database.transaction {
             queries.updateOutgoingPart(
                 part_id = partId.toString(),
                 part_status_type = statusTypeVersion,
                 part_status_blob = statusData,
                 part_completed_at = completedAt)
-            if (queries.changes().executeAsOne() != 1L) throw OutgoingPaymentPartNotFound(partId)
+            if (queries.changes().executeAsOne() != 1L) {
+                throw OutgoingPaymentPartNotFound(partId)
+            }
+            queries.getOutgoingPart(
+                part_id = partId.toString()
+            ).executeAsOneOrNull()?.let {
+                val parentId = UUID.fromString(it.part_parent_id)
+                didCompletePaymentRow(OutgoingPaymentId(parentId), database)
+            }
         }
     }
 
     fun updateOutgoingPart(partId: UUID, failure: Either<ChannelException, FailureMessage>, completedAt: Long) {
         val (statusTypeVersion, statusData) = OutgoingPaymentFailure.convertFailure(failure).mapToDb()
-        queries.transaction {
+        database.transaction {
             queries.updateOutgoingPart(
                 part_id = partId.toString(),
                 part_status_type = statusTypeVersion,
                 part_status_blob = statusData,
                 part_completed_at = completedAt
             )
-            if (queries.changes().executeAsOne() != 1L) throw OutgoingPaymentPartNotFound(partId)
+            if (queries.changes().executeAsOne() != 1L) {
+                throw OutgoingPaymentPartNotFound(partId)
+            }
+            queries.getOutgoingPart(
+                part_id = partId.toString()
+            ).executeAsOneOrNull()?.let {
+                val parentId = UUID.fromString(it.part_parent_id)
+                didCompletePaymentRow(OutgoingPaymentId(parentId), database)
+            }
         }
     }
 
@@ -124,6 +148,13 @@ class OutgoingQueries(private val queries: OutgoingPaymentsQueries) {
                 // resulting payment must contain the request part id, or should be null
                 .takeIf { p -> p.parts.map { it.id }.contains(partId) }
         }
+    }
+
+    fun getOutgoingPaymentWithoutParts(id: UUID): OutgoingPayment? {
+        return queries.getOutgoingPaymentWithoutParts(
+            id = id.toString(),
+            mapper = ::mapOutgoingPaymentWithoutParts
+        ).executeAsOneOrNull()
     }
 
     fun getOutgoingPayment(id: UUID): OutgoingPayment? {
@@ -163,6 +194,30 @@ class OutgoingQueries(private val queries: OutgoingPaymentsQueries) {
 
     companion object {
         @Suppress("UNUSED_PARAMETER")
+        fun mapOutgoingPaymentWithoutParts(
+            id: String,
+            recipient_amount_msat: Long,
+            recipient_node_id: String,
+            payment_hash: ByteArray,
+            details_type: OutgoingDetailsTypeVersion,
+            details_blob: ByteArray,
+            created_at: Long,
+            completed_at: Long?,
+            status_type: OutgoingStatusTypeVersion?,
+            status_blob: ByteArray?
+        ): OutgoingPayment {
+            return OutgoingPayment(
+                id = UUID.fromString(id),
+                recipientAmount = MilliSatoshi(recipient_amount_msat),
+                recipient = PublicKey(ByteVector(recipient_node_id)),
+                details = OutgoingDetailsData.deserialize(details_type, details_blob),
+                parts = listOf(),
+                status = mapOutgoingPaymentStatus(status_type, status_blob, completed_at),
+                createdAt = created_at
+            )
+        }
+
+        @Suppress("UNUSED_PARAMETER")
         fun mapOutgoingPayment(
             id: String,
             recipient_amount_msat: Long,
@@ -184,24 +239,56 @@ class OutgoingQueries(private val queries: OutgoingPaymentsQueries) {
         ): OutgoingPayment {
             val parts = if (part_id != null && part_amount_msat != null && part_route != null && part_created_at != null) {
                 listOf(
-                    OutgoingPayment.Part(
-                        id = UUID.fromString(part_id),
-                        amount = MilliSatoshi(part_amount_msat),
-                        route = part_route,
-                        status = mapOutgoingPartStatus(part_status_type, part_status_blob, part_completed_at),
-                        createdAt = part_created_at
+                    mapOutgoingPaymentPart(
+                        part_id,
+                        id,
+                        part_amount_msat,
+                        part_route,
+                        part_created_at,
+                        part_completed_at,
+                        part_status_type,
+                        part_status_blob
                     )
                 )
             } else emptyList()
 
-            return OutgoingPayment(
-                id = UUID.fromString(id),
-                recipientAmount = MilliSatoshi(recipient_amount_msat),
-                recipient = PublicKey(ByteVector(recipient_node_id)),
-                details = OutgoingDetailsData.deserialize(details_type, details_blob),
-                parts = parts,
-                status = mapOutgoingPaymentStatus(status_type, status_blob, completed_at),
-                createdAt = created_at
+            return mapOutgoingPaymentWithoutParts(
+                id,
+                recipient_amount_msat,
+                recipient_node_id,
+                payment_hash,
+                details_type,
+                details_blob,
+                created_at,
+                completed_at,
+                status_type,
+                status_blob
+            ).copy(
+                parts = parts
+            )
+        }
+
+        @Suppress("UNUSED_PARAMETER")
+        fun mapOutgoingPaymentPart(
+            part_id: String,
+            part_parent_id: String,
+            part_amount_msat: Long,
+            part_route: List<HopDesc>,
+            part_created_at: Long,
+            part_completed_at: Long?,
+            part_status_type: OutgoingPartStatusTypeVersion?,
+            part_status_blob: ByteArray?
+        ): OutgoingPayment.Part {
+            return OutgoingPayment.Part(
+                id = UUID.fromString(part_id),
+                amount = MilliSatoshi(part_amount_msat),
+                route = part_route,
+                status = mapOutgoingPartStatus(
+                    statusType = part_status_type,
+                    statusBlob = part_status_blob,
+                    completedAt = part_completed_at
+                ),
+                createdAt = part_created_at
             )
         }
 

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
@@ -75,6 +75,20 @@ SELECT * FROM outgoing_payment_parts WHERE part_id=?;
 deleteOutgoingPart:
 DELETE FROM outgoing_payment_parts WHERE part_id=?;
 
+getOutgoingPaymentWithoutParts:
+SELECT id,
+       recipient_amount_msat,
+       recipient_node_id,
+       payment_hash,
+       details_type,
+       details_blob,
+       created_at,
+       completed_at,
+       status_type,
+       status_blob
+FROM outgoing_payments
+WHERE id=?;
+
 getOutgoingPayment:
 SELECT parent.id,
        parent.recipient_amount_msat,

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/IncomingPaymentDbTypeVersionTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/IncomingPaymentDbTypeVersionTest.kt
@@ -21,6 +21,8 @@ import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.payment.PaymentRequest
 import fr.acinq.lightning.utils.msat
 import fr.acinq.phoenix.db.payments.*
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
@@ -1,0 +1,9 @@
+package fr.acinq.phoenix.db
+
+import fr.acinq.phoenix.db.payments.CloudKitInterface
+
+actual fun didCompletePaymentRow(id: PaymentRowId, database: PaymentsDatabase) {}
+
+actual fun makeCloudKitDb(database: PaymentsDatabase): CloudKitInterface? {
+    return null
+}


### PR DESCRIPTION
The purpose of this PR is to add a platform-specific hook function

````kotlin
expect fun didCompletePaymentRow(id: PaymentRowId, database: PaymentsDatabase)
````

The aim is to use it to backup payments to the cloud: #191 

The general idea is:

- The function should be invoked whenever a payment completes. Or whenever an already-completed payment is modified.
- The function must be invoked within the same atomic transaction that modifies the payment row.

Also, the platform-specific codebase is expected to contain much more than just a single function. Therefore, we also have a hook to initialize logic during database setup:

```kotlin
expect fun makeCloudKitDb(database: PaymentsDatabase): CloudKitInterface?
```

### Other minor changes:

In both `IncomingQueries.kt` & `OutgoingQueries.kt`, we had code that looked like this:

```kotlin
queries.transaction {
  // ...
}
```



Where `queries` is essentially a representation of the list of SQL queries in either `IncomingPayments.sq` or `OutgoingPayments.sq`. I found this to be rather confusing. We're making a transaction on the database, not on a list of queries... It just seems like some odd quirk of SQLDelight. So the code now reads:

```kotlin
database.transaction {
  // ...
}
```



Also, I added the ability to fetch an OutgoingPayment without any corresponding parts. And I simplified the mapping logic surrounding that.

