### PR TITLE
Handle V0 pay-to-open payments where the amount contains the fee

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val lightningKmp = "1.0-beta16"
+    const val lightningKmp = "snapshot"
     const val secp256k1 = "0.5.1"
 
     const val kotlin = "1.4.32"

--- a/phoenix-android/src/main/java/fr/acinq/phoenix/android/home/HomeView.kt
+++ b/phoenix-android/src/main/java/fr/acinq/phoenix/android/home/HomeView.kt
@@ -339,7 +339,7 @@ private fun PaymentLine(payment: WalletPayment) {
                 }
             }
             Spacer(modifier = Modifier.width(2.dp))
-            Text(text = WalletPayment.completedAt(payment).toRelativeDateString(), style = MaterialTheme.typography.caption.copy(fontSize = 12.sp))
+            Text(text = payment.completedAt().toRelativeDateString(), style = MaterialTheme.typography.caption.copy(fontSize = 12.sp))
         }
     }
 }

--- a/phoenix-ios/phoenix-ios/views/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/HomeView.swift
@@ -598,7 +598,7 @@ fileprivate struct PaymentCell : View, ViewName {
 	func paymentTimestamp() -> String {
 
 		if let payment = fetched.payment {
-			let timestamp = payment.timestamp()
+			let timestamp = payment.completedAt()
 			return timestamp > 0
 				? timestamp.formatDateMS()
 				: NSLocalizedString("pending", comment: "timestamp string for pending transaction")

--- a/phoenix-ios/phoenix-ios/views/PaymentView.swift
+++ b/phoenix-ios/phoenix-ios/views/PaymentView.swift
@@ -137,7 +137,7 @@ fileprivate struct SummaryView: View {
 					}
 					.font(Font.title2.bold())
 					.padding(.bottom, 2)
-					Text(payment.timestamp().formatDateMS())
+					Text(payment.completedAt().formatDateMS())
 						.font(.subheadline)
 						.foregroundColor(.secondary)
 				}
@@ -170,7 +170,7 @@ fileprivate struct SummaryView: View {
 						.font(Font.title2.uppercaseSmallCaps())
 						.padding(.bottom, 6)
 					
-					Text(payment.timestamp().formatDateMS())
+					Text(payment.completedAt().formatDateMS())
 						.font(Font.subheadline)
 						.foregroundColor(.secondary)
 					
@@ -1525,7 +1525,7 @@ extension Lightning_kmpWalletPayment {
 
 		if let outgoingPayment = self as? Lightning_kmpOutgoingPayment {
 			
-			let started = self.timestamp()
+			let started = self.completedAt()
 			var finished: Int64? = nil
 			
 			if let failed = outgoingPayment.status.asFailed() {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
@@ -109,16 +109,22 @@ class IncomingQueries(private val queries: IncomingPaymentsQueries) {
             return IncomingPayment(
                 preimage = ByteVector32(preimage),
                 origin = IncomingOriginData.deserialize(origin_type, origin_blob),
-                received = mapIncomingReceived(received_amount_msat?.msat, received_at, received_with_type, received_with_blob),
+                received = mapIncomingReceived(received_amount_msat?.msat, received_at, origin_type, received_with_type, received_with_blob),
                 createdAt = created_at
             )
         }
 
-        private fun mapIncomingReceived(amount: MilliSatoshi?, receivedAt: Long?, receivedWithTypeVersion: IncomingReceivedWithTypeVersion?, receivedWithBlob: ByteArray?): IncomingPayment.Received? {
+        private fun mapIncomingReceived(
+            amount: MilliSatoshi?,
+            receivedAt: Long?,
+            originTypeVersion: IncomingOriginTypeVersion,
+            receivedWithTypeVersion: IncomingReceivedWithTypeVersion?,
+            receivedWithBlob: ByteArray?
+        ): IncomingPayment.Received? {
             return when {
                 receivedAt == null && receivedWithTypeVersion == null && receivedWithBlob == null -> null
                 receivedAt != null && receivedWithTypeVersion != null && receivedWithBlob != null -> {
-                    IncomingPayment.Received(IncomingReceivedWithData.deserialize(receivedWithTypeVersion, receivedWithBlob, amount), receivedAt)
+                    IncomingPayment.Received(IncomingReceivedWithData.deserialize(receivedWithTypeVersion, receivedWithBlob, amount, originTypeVersion), receivedAt)
                 }
                 else -> throw UnreadableIncomingReceivedWith(receivedAt, receivedWithTypeVersion, receivedWithBlob)
             }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LightningExtensions.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LightningExtensions.kt
@@ -54,8 +54,6 @@ fun WalletPayment.paymentHashString(): String = when (this) {
     is IncomingPayment -> paymentHash.toString()
 }
 
-fun WalletPayment.timestamp(): Long = WalletPayment.completedAt(this)
-
 fun WalletPayment.errorMessage(): String? = when (this) {
     is OutgoingPayment -> when (val s = status) {
         is OutgoingPayment.Status.Completed.Failed -> s.reason.toString()

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/IncomingPaymentDbTypeVersionTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/IncomingPaymentDbTypeVersionTest.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class IncomingPaymentDbTypeVersionTest {
 
@@ -64,31 +65,90 @@ class IncomingPaymentDbTypeVersionTest {
     }
 
     @Test
-    fun incoming_receivedwith_lightning() {
+    fun incoming_receivedwith_multipart_v0_lightning() {
         val receivedWith = setOf(IncomingPayment.ReceivedWith.LightningPayment(100_000.msat, ByteVector32.One, 2L))
-        val deserialized = IncomingReceivedWithData.deserialize(IncomingReceivedWithTypeVersion.MULTIPARTS_V0, receivedWith.mapToDb()!!.second, null)
+        val deserialized = IncomingReceivedWithData.deserialize(
+            IncomingReceivedWithTypeVersion.MULTIPARTS_V0,
+            receivedWith.mapToDb()!!.second,
+            null,
+            IncomingOriginTypeVersion.INVOICE_V0
+        )
         assertEquals(receivedWith.first(), deserialized.first())
     }
 
     @Test
-    fun incoming_receivedwith_newchannel() {
-        val receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(123456789.msat, 1000.msat, channelId1))
-        val deserialized = IncomingReceivedWithData.deserialize(IncomingReceivedWithTypeVersion.MULTIPARTS_V0, receivedWith.mapToDb()!!.second, null)
+    fun incoming_receivedwith_multipart_v1_lightning() {
+        val receivedWith = setOf(IncomingPayment.ReceivedWith.LightningPayment(100_000.msat, ByteVector32.One, 2L))
+        val deserialized = IncomingReceivedWithData.deserialize(
+            IncomingReceivedWithTypeVersion.MULTIPARTS_V1,
+            receivedWith.mapToDb()!!.second,
+            null,
+            IncomingOriginTypeVersion.INVOICE_V0
+        )
+        assertEquals(receivedWith.first(), deserialized.first())
+    }
+
+    @Test
+    fun incoming_receivedwith_multipart_v0_newchannel_paytoopen() {
+        // pay-to-open with MULTIPARTS_V0: amount contains the fee which is a special case that must be fixed when deserializing.
+        val receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(2_000_000.msat, 5_000.msat, channelId1))
+        val deserialized = IncomingReceivedWithData.deserialize(
+            IncomingReceivedWithTypeVersion.MULTIPARTS_V0,
+            receivedWith.mapToDb()!!.second,
+            null,
+            IncomingOriginTypeVersion.INVOICE_V0
+        )
+        assertEquals(1, deserialized.size)
+        assertTrue { deserialized.first() is IncomingPayment.ReceivedWith.NewChannel }
+        assertEquals(5_000.msat, deserialized.first().fees)
+        assertEquals(5_000.msat, deserialized.first().fees)
+    }
+
+    @Test
+    fun incoming_receivedwith_multipart_v1_newchannel_paytoopen() {
+        val receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(1_995_000.msat, 5_000.msat, channelId1))
+        val deserialized = IncomingReceivedWithData.deserialize(
+            IncomingReceivedWithTypeVersion.MULTIPARTS_V1,
+            receivedWith.mapToDb()!!.second,
+            null,
+            IncomingOriginTypeVersion.INVOICE_V0
+        )
         assertEquals(receivedWith, deserialized)
     }
 
     @Test
-    fun incoming_receivedwith_newchannel_null() {
+    fun incoming_receivedwith_multipart_v0_newchannel_swapin_nochannel() {
         val receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(111111111.msat, 1000.msat, null))
-        val deserialized = IncomingReceivedWithData.deserialize(IncomingReceivedWithTypeVersion.MULTIPARTS_V0, receivedWith.mapToDb()!!.second, null)
+        val deserialized = IncomingReceivedWithData.deserialize(
+            IncomingReceivedWithTypeVersion.MULTIPARTS_V0,
+            receivedWith.mapToDb()!!.second,
+            null,
+            IncomingOriginTypeVersion.SWAPIN_V0
+        )
+        assertEquals(receivedWith, deserialized)
+    }
+
+    @Test
+    fun incoming_receivedwith_multipart_v1_newchannel_swapin_nochannel() {
+        val receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(164495787.msat, 4058671.msat, null))
+        val deserialized = IncomingReceivedWithData.deserialize(
+            IncomingReceivedWithTypeVersion.MULTIPARTS_V1,
+            receivedWith.mapToDb()!!.second,
+            null,
+            IncomingOriginTypeVersion.SWAPIN_V0
+        )
         assertEquals(receivedWith, deserialized)
     }
 
     @Test
     fun incoming_receivedwith_lightning_legacy() {
-        val deserialized = IncomingReceivedWithData.deserialize(IncomingReceivedWithTypeVersion.LIGHTNING_PAYMENT_V0,
-            Json.encodeToString(IncomingReceivedWithData.LightningPayment.V0).toByteArray(Charsets.UTF_8), 999_999.msat)
-            .first() as IncomingPayment.ReceivedWith.LightningPayment
+        val deserialized = IncomingReceivedWithData.deserialize(
+            IncomingReceivedWithTypeVersion.LIGHTNING_PAYMENT_V0,
+            Json.encodeToString(IncomingReceivedWithData.LightningPayment.V0).toByteArray(Charsets.UTF_8),
+            999_999.msat,
+            IncomingOriginTypeVersion.INVOICE_V0
+        ).first() as IncomingPayment.ReceivedWith.LightningPayment
+
         assertEquals(999_999.msat, deserialized.amount)
         assertEquals(0.msat, deserialized.fees)
         assertEquals(ByteVector32.Zeroes, deserialized.channelId)
@@ -97,8 +157,12 @@ class IncomingPaymentDbTypeVersionTest {
 
     @Test
     fun incoming_receivedwith_newchannel_legacy() {
-        val deserialized = IncomingReceivedWithData.deserialize(IncomingReceivedWithTypeVersion.NEW_CHANNEL_V0,
-            Json.encodeToString(IncomingReceivedWithData.NewChannel.V0(15_000.msat, channelId1)).toByteArray(Charsets.UTF_8), 123_456.msat)
+        val deserialized = IncomingReceivedWithData.deserialize(
+            IncomingReceivedWithTypeVersion.NEW_CHANNEL_V0,
+            Json.encodeToString(IncomingReceivedWithData.NewChannel.V0(15_000.msat, channelId1)).toByteArray(Charsets.UTF_8),
+            123_456.msat,
+            IncomingOriginTypeVersion.SWAPIN_V0
+        )
             .first() as IncomingPayment.ReceivedWith.NewChannel
         assertEquals(123_456.msat, deserialized.amount)
         assertEquals(15_000.msat, deserialized.fees)


### PR DESCRIPTION
This commit depends on https://github.com/ACINQ/lightning-kmp/pull/290

Old pay-to-open (`L2 -> L2` requiring a new channel to be created) stored the fee in the amount field which is not correct anymore (see PR linked above). 

To fix that we add a new `MULTIPART_V1` version and uses the `IncomingReceivedWithData.deserializer` method to discriminate the old pay-to-open payments from the rest, and subtract the fee from the amount in that case.

A side effect is that the `IncomingReceivedWithData.deserializer` now needs the payment's `IncomingOriginTypeVersion` to know whether this is a swap-in or a pay-to-open.

Fixes https://github.com/ACINQ/phoenix/issues/170