### PR TITLE
Fixes issue #189

### DIFF
--- a/phoenix-shared/src/androidTest/kotlin/fr/acinq/phoenix/db/SqliteChannelsDatabaseTest.kt
+++ b/phoenix-shared/src/androidTest/kotlin/fr/acinq/phoenix/db/SqliteChannelsDatabaseTest.kt
@@ -30,3 +30,7 @@ actual fun testPaymentsDriver(): SqlDriver {
     PaymentsDatabase.Schema.create(driver)
     return driver
 }
+
+actual fun isIOS(): Boolean {
+    return false
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
@@ -47,7 +47,7 @@ class SqlitePaymentsDb(private val driver: SqlDriver) : PaymentsDb {
         incoming_paymentsAdapter = Incoming_payments.Adapter(origin_typeAdapter = EnumColumnAdapter(), received_with_typeAdapter = EnumColumnAdapter())
     )
     internal val inQueries = IncomingQueries(database.incomingPaymentsQueries)
-    private val outQueries = OutgoingQueries(database.outgoingPaymentsQueries)
+    internal val outQueries = OutgoingQueries(database.outgoingPaymentsQueries)
     private val aggrQueries = database.aggregatedQueriesQueries
 
     override suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>) {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
@@ -34,13 +34,11 @@ import fracinqphoenixdb.OutgoingPaymentsQueries
 
 class OutgoingQueries(private val queries: OutgoingPaymentsQueries) {
 
-    fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>): Boolean {
-        var result = true
-        if (parts.size == 0) {
-            return result
-        }
+    fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>) {
+        if (parts.size == 0) return
         queries.transaction {
             parts.map {
+                // This will throw an exception if the sqlite foreign-key-constraint is violated.
                 queries.addOutgoingPart(
                     part_id = it.id.toString(),
                     part_parent_id = parentId.toString(),
@@ -49,11 +47,7 @@ class OutgoingQueries(private val queries: OutgoingPaymentsQueries) {
                     part_created_at = it.createdAt
                 )
             }
-            if (queries.changes().executeAsOne() != 1L) {
-                result = false
-            }
         }
-        return result
     }
 
     fun addOutgoingPayment(outgoingPayment: OutgoingPayment) {

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/SqlitePaymentsDatabaseTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/SqlitePaymentsDatabaseTest.kt
@@ -217,9 +217,9 @@ class SqlitePaymentsDatabaseTest {
             // The problem is that foreign key constraints are disabled.
             // See iosDbFactory.kt for discussion.
         } else {
-            assertFalse { db.outQueries.addOutgoingParts(UUID.randomUUID(), newParts) }
+            assertFails { db.addOutgoingParts(UUID.randomUUID(), newParts) }
             // New parts must have a unique id.
-            assertFalse { db.outQueries.addOutgoingParts(
+            assertFails { db.addOutgoingParts(
                 parentId = onePartFailed.id,
                 parts = newParts.map { it.copy(id = p.parts[0].id) }
             ) }

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/SqlitePaymentsDatabaseTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/SqlitePaymentsDatabaseTest.kt
@@ -203,8 +203,8 @@ class SqlitePaymentsDatabaseTest {
         p.parts.forEach { assertEquals(onePartFailed, db.getOutgoingPart(it.id)) }
 
         // We should never update non-existing parts.
-        assertFails { db.updateOutgoingPart(UUID.randomUUID(), Either.Right(TemporaryNodeFailure)) }
-        assertFails { db.updateOutgoingPart(UUID.randomUUID(), randomBytes32()) }
+        assertFalse { db.outQueries.updateOutgoingPart(UUID.randomUUID(), Either.Right(TemporaryNodeFailure), 110) }
+        assertFalse { db.outQueries.updateOutgoingPart(UUID.randomUUID(), randomBytes32(), 110) }
 
         // Other payment parts are added.
         val newParts = listOf(
@@ -212,12 +212,18 @@ class SqlitePaymentsDatabaseTest {
             OutgoingPayment.Part(UUID.randomUUID(), 10_000.msat, listOf(HopDesc(Lightning.randomKey().publicKey(), Lightning.randomKey().publicKey())), OutgoingPayment.Part.Status.Pending, 120),
         )
         // Parts need a valid parent.
-        // NB: This test fails on iOS !
-        // The problem is that foreign key constraints are disabled.
-        // See iosDbFactory.kt for discussion.
-        assertFails { db.addOutgoingParts(UUID.randomUUID(), newParts) }
-        // New parts must have a unique id.
-        assertFails { db.addOutgoingParts(onePartFailed.id, newParts.map { it.copy(id = p.parts[0].id) }) }
+        if (isIOS()) {
+            // This is a known bug in SQLDelight on iOS.
+            // The problem is that foreign key constraints are disabled.
+            // See iosDbFactory.kt for discussion.
+        } else {
+            assertFalse { db.outQueries.addOutgoingParts(UUID.randomUUID(), newParts) }
+            // New parts must have a unique id.
+            assertFalse { db.outQueries.addOutgoingParts(
+                parentId = onePartFailed.id,
+                parts = newParts.map { it.copy(id = p.parts[0].id) }
+            ) }
+        }
 
         // Can add new parts to existing payment.
         db.addOutgoingParts(onePartFailed.id, newParts)
@@ -245,8 +251,9 @@ class SqlitePaymentsDatabaseTest {
         // Parts are successful BUT parent payment is not successful yet.
         assertTrue(db.getOutgoingPayment(p.id)!!.status is OutgoingPayment.Status.Pending)
 
+        val paymentStatus = OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage, 130)
         val paymentSucceeded = partsSettled.copy(
-            status = OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage, 130),
+            status = paymentStatus,
             parts = partsSettled.parts.drop(1)
         )
         db.completeOutgoingPayment(p.id, preimage, 130)
@@ -255,7 +262,10 @@ class SqlitePaymentsDatabaseTest {
         assertEquals(paymentSucceeded, db.getOutgoingPayment(p.id))
 
         // Cannot succeed a payment that does not exist
-        assertFails { db.completeOutgoingPayment(UUID.randomUUID(), preimage, 130) }
+        assertFalse { db.outQueries.completeOutgoingPayment(
+            id = UUID.randomUUID(),
+            completed = paymentStatus
+        ) }
         // Using failed part id does not return a settled payment
         assertNull(db.getOutgoingPart(partsSettled.parts[0].id))
         partsSettled.parts.drop(1).forEach {
@@ -292,11 +302,17 @@ class SqlitePaymentsDatabaseTest {
         assertEquals(partsFailed, db.getOutgoingPayment(p.id))
         p.parts.forEach { assertEquals(partsFailed, db.getOutgoingPart(it.id)) }
 
-        val paymentFailed = partsFailed.copy(status = OutgoingPayment.Status.Completed.Failed(FinalFailure.NoRouteToRecipient, 120))
-        db.completeOutgoingPayment(p.id, FinalFailure.NoRouteToRecipient, 120)
-        assertFails { db.completeOutgoingPayment(UUID.randomUUID(), FinalFailure.NoRouteToRecipient, 120) }
+        val paymentStatus = OutgoingPayment.Status.Completed.Failed(
+            reason = FinalFailure.NoRouteToRecipient,
+            completedAt = 120
+        )
+        val paymentFailed = partsFailed.copy(status = paymentStatus)
+        db.completeOutgoingPayment(p.id, paymentStatus)
         assertEquals(paymentFailed, db.getOutgoingPayment(p.id))
         p.parts.forEach { assertEquals(paymentFailed, db.getOutgoingPart(it.id)) }
+
+        // Cannot fail a payment that does not exist
+        assertFalse { db.outQueries.completeOutgoingPayment(UUID.randomUUID(), paymentStatus) }
     }
 
     companion object {
@@ -313,3 +329,6 @@ class SqlitePaymentsDatabaseTest {
 }
 
 expect fun testPaymentsDriver(): SqlDriver
+
+// Workaround for known bugs in SQLDelight on native/iOS.
+expect fun isIOS(): Boolean

--- a/phoenix-shared/src/iosTest/kotlin/fr/acinq/phoenix/db/SqliteChannelsDatabaseTest.kt
+++ b/phoenix-shared/src/iosTest/kotlin/fr/acinq/phoenix/db/SqliteChannelsDatabaseTest.kt
@@ -26,7 +26,8 @@ actual fun testChannelsDriver(): SqlDriver {
 
 actual fun testPaymentsDriver(): SqlDriver {
     // In-memory databases don't seem to work on native/iOS.
-    // This creates a persistent database, which breaks our unit test logic.
+    // The call succeeds, but in reality it creates a persistent database,
+    // which then breaks our unit test logic.
 //  return NativeSqliteDriver(PaymentsDatabase.Schema, ":memory:")
     // The docs reference other ways of making in-memory databases:
     // https://sqlite.org/inmemorydb.html
@@ -35,4 +36,9 @@ actual fun testPaymentsDriver(): SqlDriver {
     // Current workaround is to create a fresh database for each test.
     val randomName = Lightning.randomBytes32().toHex()
     return NativeSqliteDriver(PaymentsDatabase.Schema, randomName)
+}
+
+// Workaround for known bugs in SQLDelight on native/iOS.
+actual fun isIOS(): Boolean {
+    return true
 }


### PR DESCRIPTION
As reported in issue #189, a crash occurs when:

- a channel with a zero local-balance is closed, which doesn't create a corresponding OutgoingPayment in the database
- later, the channel-closing tx is confirmed on the blockchain
- the code calls `db.completeOutgoingPayment`, which explicitly throws an exception because the referenced payment isn't found

The proposed solutions were:

- go ahead and add a corresponding OutgoingPayment, even though the amount is zero
- don't throw an exception

As discussed earlier, it may seem odd (from the user's perspective) to see a transaction in the UI with a zero amount. So the recommended solution is to no longer throw an exception.

This PR changes 4 methods in OutgoingQueries.kt: **instead of throwing exceptions, they now return false if the database was missing the referenced item**.

#### Note 1:
I don't have a strong opinion, one way or the other, concerning exceptions vs booleans. I just changed them all for consistency. But if you feel differently, we can change it back.

#### Note 2:
I intended to add a `log.warning` to SqlitePaymentsDb if any of the changed methods returned false. However, passing the `loggerFactory` instance to this class caused the dreaded FreezingException:
> Caused by: kotlin.native.concurrent.FreezingException: freezing of Continuation @ $listPaymentsCountFlow$lambda-16COROUTINE$102 has failed, first blocker is fr.acinq.phoenix.utils.LogMemory@bf61c8
---

Also, SqlitePaymentsDatabaseTest has been broken on iOS for quite some time now. This was due to a known bug in SQLDelight:

> foreign key constraints don't currently work on native/iOS



So I've added a workaround so that the unit test works again.