### PR TITLE
Adding cloud serialization & deserialization

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudHelper.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudHelper.kt
@@ -1,0 +1,19 @@
+package fr.acinq.phoenix.db.cloud
+
+import io.ktor.util.*
+
+// Kotlin wants to encode a ByteArray like this: {
+//   "fail": [123,34,112,97,121,109,101,110,116,82,101,113,117]
+// }
+//
+// Lol. If we don't use Cbor, then we should at least use Base64.
+
+@OptIn(InternalAPI::class)
+fun ByteArray.b64Encode(): String {
+    return this.encodeBase64() // io.ktor.util
+}
+
+@OptIn(InternalAPI::class)
+fun String.b64Decode(): ByteArray {
+    return this.decodeBase64Bytes() // io.ktor.util
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudSerializers.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudSerializers.kt
@@ -1,0 +1,117 @@
+package fr.acinq.phoenix.db.cloud
+
+import fr.acinq.bitcoin.ByteVector
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.lightning.utils.UUID
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.ByteString
+import kotlinx.serialization.cbor.Cbor
+import kotlinx.serialization.cbor.CborBuilder
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.serializer
+
+// Notes from the field:
+//
+// Consider the following JSON:
+// {
+//   "preimage":"JuO9VOOW/5pzCKsaCO7a9E/ETS7Bef5yyWVRBJBYmOQ=",
+//   "origin":{
+//     "type":"INVOICE_V0",
+//     "blob":"eyJwYXltZW50UmVxdWVzdCI6ImxudGIxMDB1MXBzMDNmc3VwcDVnbmh4NmR4NTA4cnM3OG1kcnB3Y3U3cWgwNGZja3hjbmRhdXdueXp1NjRuM3V5dzRqZHRzZHE1ZmFjeDJtM3F2ZDV4em1ud3Y0a3FjcXBqc3A1aHIyZDg1cDdkNm5xcGtyZXVtNGo5czZycjBwaG1weGhzdzVqYXJyNTI5ZGxsYXY5MGZ3cTlxdHpxcXFxcXF5c2dxeHF5anc1cXJ6anF3Zm4zcDkyNzh0dHp6cGUwZTAwdWh5eGhuZWQzajVkOWFjcWFrNWVtd2ZwZmxwOHoyY25mbGNmemNhODA1NmsweXFxcXFsZ3FxcXFxZXFxanFmOTN4M3YyM3IwZTg1a3p5cXJlaDY4ZGhxbGQwY2w3and4OTdwZDZwemF4Y2N1Y3l3NzhxZGc1ZzJsdzhrZnlmdWQzMnN4d2NtNDlhY2wwNXdxd3phajA4djdyeHQ5cWZ4Z2E3MDNzcGhrcmZhdCJ9"
+//   },
+//   "received":{
+//     "ts":1626908236089,
+//     "type":"MULTIPARTS_V0",
+//     "blob":"W3sidHlwZSI6ImZyLmFjaW5xLnBob2VuaXguZGIucGF5bWVudHMuSW5jb21pbmdSZWNlaXZlZFdpdGhEYXRhLlBhcnQuTmV3Q2hhbm5lbC5WMCIsImFtb3VudCI6eyJtc2F0IjoxMDAwMDAwMH0sImZlZXMiOnsibXNhdCI6MzAwMDAwMH0sImNoYW5uZWxJZCI6bnVsbH1d"
+//   },
+//   "createdAt":1626908189069
+// }
+//
+// Now there are 4 different ways in which we can encode this data.
+//
+// 1. Use JSON serialization, and encode the data as Base64.
+//    The output looks exactly like the above.
+//    ```
+//    @Serializable(with = ByteVector32JsonSerializer::class)
+//    val preimage: ByteVector32
+//    ```
+//
+// 2. Use CBOR serialization, and encode the data as Base64.
+//    ```
+//    @Serializable(with = ByteVector32JsonSerializer::class)
+//    val preimage: ByteVector32
+//    ```
+//
+// 3. Use CBOR serialization, and encode the data as ByteArray.
+//    Since CBOR supports raw data, this should encode smaller.
+//    ```
+//    val preimage: ByteArray
+//    ```
+//
+// 4. Use CBOR serialization, and encode the data as ByteArray w/ByteString.
+//    The docs mention that we can opt-in to use CBOR major type 2.
+//    ```
+//    @ByteString
+//    val preimage: ByteArray
+//    ```
+//
+// After attempting all the above options, here are the results:
+// 1.   915 bytes
+// 2.   883 bytes
+// 3. 1,256 bytes (huh?)
+// 4.   690 bytes !
+//
+// The winner is CBOR with @ByteString.
+
+object ByteVectorJsonSerializer : KSerializer<ByteVector> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ByteVector", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: ByteVector) {
+        return encoder.encodeString(value.toByteArray().b64Encode())
+    }
+
+    override fun deserialize(decoder: Decoder): ByteVector {
+        return ByteVector(decoder.decodeString().b64Decode())
+    }
+}
+
+object ByteVector32JsonSerializer : KSerializer<ByteVector32> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ByteVector32", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: ByteVector32) {
+        return encoder.encodeString(value.toByteArray().b64Encode())
+    }
+
+    override fun deserialize(decoder: Decoder): ByteVector32 {
+        return ByteVector32(decoder.decodeString().b64Decode())
+    }
+}
+
+// A UUID is serialized as: {
+//   "mostSignificantBits":-1321539888342873580,
+//   "leastSignificantBits":-7509590717981962141
+// }
+//
+// But we can decrease the size.
+//
+
+object UUIDSerializer : KSerializer<UUID> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: UUID) {
+        return encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): UUID {
+        return UUID.fromString(decoder.decodeString())
+    }
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudType.kt
@@ -52,6 +52,12 @@ import org.kodein.memory.util.freeze
 // This is improved using a custom serializer.
 //
 
+enum class CloudDataVersion(val value: Int) {
+    // Initial version
+    V0(0)
+    // Future versions go here
+}
+
 @Serializable
 data class CloudData @OptIn(ExperimentalSerializationApi::class) constructor(
     @ByteString
@@ -66,17 +72,17 @@ data class CloudData @OptIn(ExperimentalSerializationApi::class) constructor(
     @SerialName("p")
     val padding: ByteArray?,
 ) {
-    constructor(incoming: IncomingPayment, version: Int) : this(
+    constructor(incoming: IncomingPayment, version: CloudDataVersion) : this(
         incoming = IncomingPaymentWrapper(incoming),
         outgoing = null,
-        version = version,
+        version = version.value,
         padding = ByteArray(size = 0)
     )
 
-    constructor(outgoing: OutgoingPayment, version: Int) : this(
+    constructor(outgoing: OutgoingPayment, version: CloudDataVersion) : this(
         incoming = null,
         outgoing = OutgoingPaymentWrapper(outgoing),
-        version = version,
+        version = version.value,
         padding = ByteArray(size = 0)
     )
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudType.kt
@@ -1,0 +1,116 @@
+package fr.acinq.phoenix.db.cloud
+
+import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.db.OutgoingPayment
+import kotlinx.serialization.*
+import kotlinx.serialization.cbor.ByteString
+import kotlinx.serialization.cbor.Cbor
+import kotlinx.serialization.json.Json
+import org.kodein.memory.util.freeze
+
+// Architecture & Notes:
+//
+// We make every attempt to re-use code from the database serialization routines.
+// However, cloud serialization is a bit different from database serialization.
+//
+// DIFFERENCE #1:
+//
+// SqlDelight allows us to version the database, and make changes to the database structure.
+// For example, when upgrading the app from v1.5 to v1.6,
+// we might upgrade the database from v2 to v3.
+// This upgrade mechanism allows us to write code that **only** supports database v3,
+// since SqlDelight handles the upgrade mechanics.
+//
+// This upgrade mechanism isn't available for the cloud.
+// Thus, in the cloud we might have serialized objects in v1, v2, v3...
+// And we will need to support deserializing all these versions.
+//
+// DIFFERENCE #2:
+//
+// For the local system, space is cheap, and the disk is fast.
+// But for the cloud, space is really expensive.
+// On iOS, the user only has 5 GB. But that's NOT per app.
+// That 5GB is meant to be shared by every app on their phone.
+// Which means we're expected to be a good steward of their cloud space.
+//
+// So we make certain changes.
+//
+// OPTIMIZATION #1:
+//
+// We use CBOR instead of JSON.
+// This allows us to very efficiently encode ByteArray's.
+//
+// For a discussion of the space savings in practice,
+// see the comments in CloudSerializers.kt.
+//
+// OPTIMIZATION #2:
+//
+// UUID is serialized as: {
+//   mostSignificantBits: Long,
+//   leastSignificantBits: Long
+// }
+// This is improved using a custom serializer.
+//
+
+@Serializable
+data class CloudData @OptIn(ExperimentalSerializationApi::class) constructor(
+    @ByteString
+    @SerialName("i")
+    val incoming: IncomingPaymentWrapper?,
+    @ByteString
+    @SerialName("o")
+    val outgoing: OutgoingPaymentWrapper?,
+    @SerialName("v")
+    val version: Int,
+    @ByteString
+    @SerialName("p")
+    val padding: ByteArray?,
+) {
+    constructor(incoming: IncomingPayment, version: Int) : this(
+        incoming = IncomingPaymentWrapper(incoming),
+        outgoing = null,
+        version = version,
+        padding = ByteArray(size = 0)
+    )
+
+    constructor(outgoing: OutgoingPayment, version: Int) : this(
+        incoming = null,
+        outgoing = OutgoingPaymentWrapper(outgoing),
+        version = version,
+        padding = ByteArray(size = 0)
+    )
+
+    // This function exists because the Kotlin-generated
+    // copy function doesn't translate to iOS very well.
+    //
+    fun copyWithPadding(padding: ByteArray): CloudData {
+       return this.copy(padding = padding)
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+fun CloudData.cborSerialize(): ByteArray {
+    return Cbor.encodeToByteArray(this)
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+fun CloudData.Companion.cborDeserialize(blob: ByteArray): CloudData? {
+    var result: CloudData? = null
+    try {
+        result = Cbor.decodeFromByteArray(blob)
+    } catch (e: Throwable) {}
+
+    return result?.freeze()
+}
+
+// For DEBUGGING:
+//
+// You can use the jsonSerializer to see what the data looks like.
+// Just keep in mind that the ByteArray's will be encoded super-inefficiently.
+// That's because we're optimizing for Cbor.
+// To optimize for JSON, you would use ByteVector's,
+// and encode the data as Base64 via ByteVectorJsonSerializer.
+
+fun CloudData.jsonSerialize(): ByteArray {
+    return Json.encodeToString(this).encodeToByteArray()
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudType.kt
@@ -86,6 +86,13 @@ data class CloudData @OptIn(ExperimentalSerializationApi::class) constructor(
     fun copyWithPadding(padding: ByteArray): CloudData {
        return this.copy(padding = padding)
     }
+
+    // This function exists because the `freeze()`
+    // function isn't exposed to iOS.
+    //
+    fun copyAndFreeze(): CloudData {
+        return this.freeze()
+    }
 }
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -100,7 +107,7 @@ fun CloudData.Companion.cborDeserialize(blob: ByteArray): CloudData? {
         result = Cbor.decodeFromByteArray(blob)
     } catch (e: Throwable) {}
 
-    return result?.freeze()
+    return result
 }
 
 // For DEBUGGING:

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/IncomingType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/IncomingType.kt
@@ -1,0 +1,113 @@
+package fr.acinq.phoenix.db.cloud
+
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.phoenix.db.payments.*
+import kotlinx.serialization.*
+import kotlinx.serialization.cbor.ByteString
+import kotlinx.serialization.cbor.Cbor
+
+@Serializable
+data class IncomingPaymentWrapper @OptIn(ExperimentalSerializationApi::class) constructor(
+    @ByteString
+    val preimage: ByteArray,
+    val origin: OriginWrapper,
+    val received: ReceivedWrapper?,
+    val createdAt: Long
+) {
+    constructor(payment: IncomingPayment): this(
+        preimage = payment.preimage.toByteArray(),
+        origin = OriginWrapper(payment.origin),
+        received = ReceivedWrapper(payment.received),
+        createdAt = payment.createdAt
+    )
+
+    fun unwrap(): IncomingPayment {
+        val unwrappedReceived = received?.let {
+            val originTypeVersion = IncomingOriginTypeVersion.valueOf(origin.type)
+            it.unwrap(originTypeVersion)
+        }
+        return IncomingPayment(
+            preimage = ByteVector32(preimage),
+            origin = origin.unwrap(),
+            received = unwrappedReceived,
+            createdAt = createdAt
+        )
+    }
+
+    @Serializable
+    data class OriginWrapper @OptIn(ExperimentalSerializationApi::class) constructor(
+        val type: String,
+        @ByteString
+        val blob: ByteArray
+    ) {
+        companion object {
+            // constructor
+            operator fun invoke(origin: IncomingPayment.Origin): OriginWrapper {
+                val (type, blob) = origin.mapToDb()
+                return OriginWrapper(
+                    type = type.name,
+                    blob = blob
+                )
+            }
+        }
+
+        fun unwrap(): IncomingPayment.Origin {
+            return IncomingOriginData.deserialize(
+                typeVersion = IncomingOriginTypeVersion.valueOf(type),
+                blob = blob
+            )
+        }
+    } // </OriginWrapper>
+
+    @Serializable
+    data class ReceivedWrapper @OptIn(ExperimentalSerializationApi::class) constructor(
+        val ts: Long, // timestamp / receivedAt
+        val type: String,
+        @ByteString
+        val blob: ByteArray
+    ) {
+        companion object {
+            // constructor
+            operator fun invoke(received: IncomingPayment.Received?): ReceivedWrapper? {
+                return received?.receivedWith?.mapToDb()?.let { tuple ->
+                    val (type, blob) = tuple
+                    ReceivedWrapper(
+                        ts = received.receivedAt,
+                        type = type.name,
+                        blob = blob
+                    )
+                }
+            }
+        }
+
+        fun unwrap(originTypeVersion: IncomingOriginTypeVersion): IncomingPayment.Received {
+            val receivedWith = IncomingReceivedWithData.deserialize(
+                typeVersion = IncomingReceivedWithTypeVersion.valueOf(type),
+                blob = blob,
+                amount = null, // deprecated: amount is now encoded in each part
+                originTypeVersion = originTypeVersion
+            )
+            return IncomingPayment.Received(
+                receivedWith = receivedWith,
+                receivedAt = ts
+            )
+        }
+    } // </ReceivedWrapper>
+
+} // </IncomingPaymentData>
+
+@OptIn(ExperimentalSerializationApi::class)
+fun IncomingPayment.cborSerialize(): ByteArray {
+    val wrapper = IncomingPaymentWrapper(payment = this)
+    return Cbor.encodeToByteArray(wrapper)
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+fun IncomingPaymentWrapper.Companion.cborDeserialize(blob: ByteArray): IncomingPayment? {
+    var result: IncomingPayment? = null
+    try {
+        result = Cbor.decodeFromByteArray<IncomingPaymentWrapper>(blob).unwrap()
+    } catch (e: Throwable) {}
+    return result
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/OutgoingPartType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/OutgoingPartType.kt
@@ -1,0 +1,76 @@
+package fr.acinq.phoenix.db.cloud
+
+import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.lightning.db.OutgoingPayment
+import fr.acinq.lightning.utils.UUID
+import fr.acinq.phoenix.db.payments.*
+import kotlinx.serialization.*
+import kotlinx.serialization.cbor.ByteString
+
+@Serializable
+data class OutgoingPartWrapper(
+    @Serializable(with = UUIDSerializer::class)
+    val id: UUID,
+    val msat: Long,
+    val route: String,
+    val status: StatusWrapper?,
+    val createdAt: Long
+) {
+    constructor(part: OutgoingPayment.Part): this(
+        id = part.id,
+        msat = part.amount.msat,
+        route = OutgoingQueries.hopDescAdapter.encode(part.route),
+        status = StatusWrapper(part.status),
+        createdAt = part.createdAt
+    )
+
+    fun unwrap() = OutgoingPayment.Part(
+        id = id,
+        amount = MilliSatoshi(msat = msat),
+        route = OutgoingQueries.hopDescAdapter.decode(route),
+        status = status?.unwrap() ?: OutgoingPayment.Part.Status.Pending,
+        createdAt = createdAt
+    )
+
+    @Serializable
+    data class StatusWrapper @OptIn(ExperimentalSerializationApi::class) constructor(
+        val ts: Long, // timestamp: completedAt
+        val type: String,
+        @ByteString
+        val blob: ByteArray
+    ) {
+        companion object {
+            // constructor
+            operator fun invoke(status: OutgoingPayment.Part.Status): StatusWrapper? {
+                return when (status) {
+                    is OutgoingPayment.Part.Status.Pending -> null
+                    is OutgoingPayment.Part.Status.Failed -> {
+                        val (type, blob) = status.mapToDb()
+                        StatusWrapper(
+                            ts = status.completedAt,
+                            type = type.name,
+                            blob = blob
+                        )
+                    }
+                    is OutgoingPayment.Part.Status.Succeeded -> {
+                        val (type, blob) = status.mapToDb()
+                        StatusWrapper(
+                            ts = status.completedAt,
+                            type = type.name,
+                            blob = blob
+                        )
+                    }
+                }
+            }
+        } // </companion object>
+
+        fun unwrap(): OutgoingPayment.Part.Status {
+            return OutgoingPartStatusData.deserialize(
+                typeVersion = OutgoingPartStatusTypeVersion.valueOf(type),
+                blob = blob,
+                completedAt = ts
+            )
+        }
+    } // </StatusWrapper>
+
+} // </OutgoingPartData>

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/OutgoingType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/OutgoingType.kt
@@ -1,0 +1,129 @@
+package fr.acinq.phoenix.db.cloud
+
+import fr.acinq.bitcoin.ByteVector
+import fr.acinq.bitcoin.PublicKey
+import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.db.OutgoingPayment
+import fr.acinq.lightning.utils.UUID
+import fr.acinq.phoenix.db.payments.*
+import kotlinx.serialization.*
+import kotlinx.serialization.cbor.ByteString
+import kotlinx.serialization.cbor.Cbor
+
+@Serializable
+data class OutgoingPaymentWrapper @OptIn(ExperimentalSerializationApi::class) constructor(
+    @Serializable(with = UUIDSerializer::class)
+    val id: UUID,
+    val msat: Long,
+    @ByteString
+    val recipient: ByteArray,
+    val details: DetailsWrapper,
+    val parts: List<OutgoingPartWrapper>,
+    val status: StatusWrapper?,
+    val createdAt: Long
+) {
+    constructor(payment: OutgoingPayment): this(
+        id = payment.id,
+        msat = payment.recipientAmount.msat,
+        recipient = payment.recipient.value.toByteArray(),
+        details = DetailsWrapper(payment.details),
+        parts = payment.parts.map { OutgoingPartWrapper(it) },
+        status = StatusWrapper(payment.status),
+        createdAt = payment.createdAt
+    )
+
+    fun unwrap() = OutgoingPayment(
+        id = id,
+        amount = MilliSatoshi(msat = msat),
+        recipient = PublicKey(ByteVector(recipient)),
+        details = details.unwrap()
+    ).copy(
+        parts = parts.map { it.unwrap() },
+        status = status?.unwrap() ?: OutgoingPayment.Status.Pending,
+        createdAt = createdAt
+    )
+
+    @Serializable
+    data class DetailsWrapper @OptIn(ExperimentalSerializationApi::class) constructor(
+        val type: String,
+        @ByteString
+        val blob: ByteArray
+    ) {
+        companion object {
+            // constructor
+            operator fun invoke(details: OutgoingPayment.Details): DetailsWrapper {
+                val (type, blob) = details.mapToDb()
+                return DetailsWrapper(
+                    type = type.name,
+                    blob = blob
+                )
+            }
+        }
+
+        fun unwrap(): OutgoingPayment.Details {
+            return OutgoingDetailsData.deserialize(
+                typeVersion = OutgoingDetailsTypeVersion.valueOf(type),
+                blob = blob
+            )
+        }
+    } // </DetailsWrapper>
+
+    @Serializable
+    data class StatusWrapper @OptIn(ExperimentalSerializationApi::class) constructor(
+        val ts: Long,
+        val type: String,
+        @ByteString
+        val blob: ByteArray
+    ) {
+        companion object {
+            // constructor
+            operator fun invoke(status: OutgoingPayment.Status): StatusWrapper? {
+                return when (status) {
+                    is OutgoingPayment.Status.Pending -> null
+                    is OutgoingPayment.Status.Completed.Failed -> {
+                        val (type, blob) = status.mapToDb()
+                        StatusWrapper(
+                            ts = status.completedAt,
+                            type = type.name,
+                            blob = blob
+                        )
+                    }
+                    is OutgoingPayment.Status.Completed.Succeeded -> {
+                        val (type, blob) = status.mapToDb()
+                        StatusWrapper(
+                            ts = status.completedAt,
+                            type = type.name,
+                            blob = blob
+                        )
+                    }
+                }
+            }
+        } // </companion object>
+
+        fun unwrap(): OutgoingPayment.Status {
+            return OutgoingStatusData.deserialize(
+                typeVersion = OutgoingStatusTypeVersion.valueOf(type),
+                blob = blob,
+                completedAt = ts
+            )
+        }
+
+    } // </StatusWrapper>
+
+} // </OutgoingPaymentData>
+
+@OptIn(ExperimentalSerializationApi::class)
+fun OutgoingPayment.cborSerialize(): ByteArray {
+    val wrapper = OutgoingPaymentWrapper(payment = this)
+    return Cbor.encodeToByteArray(wrapper)
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+fun OutgoingPaymentWrapper.Companion.cborDeserialize(blob: ByteArray): OutgoingPayment? {
+    var result: OutgoingPayment? = null
+    try {
+        result = Cbor.decodeFromByteArray<OutgoingPaymentWrapper>(blob).unwrap()
+    } catch (e: Throwable) {}
+    return result
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
@@ -329,12 +329,15 @@ class OutgoingQueries(val database: PaymentsDatabase) {
         }
 
         val hopDescAdapter: ColumnAdapter<List<HopDesc>, String> = object : ColumnAdapter<List<HopDesc>, String> {
-            override fun decode(databaseValue: String): List<HopDesc> = databaseValue.split(";").map { hop ->
-                val els = hop.split(":")
-                val n1 = PublicKey(ByteVector(els[0]))
-                val n2 = PublicKey(ByteVector(els[1]))
-                val cid = els[2].takeIf { it.isNotBlank() }?.run { ShortChannelId(this) }
-                HopDesc(n1, n2, cid)
+            override fun decode(databaseValue: String): List<HopDesc> = when {
+                databaseValue.isEmpty() -> listOf()
+                else -> databaseValue.split(";").map { hop ->
+                    val els = hop.split(":")
+                    val n1 = PublicKey(ByteVector(els[0]))
+                    val n2 = PublicKey(ByteVector(els[1]))
+                    val cid = els[2].takeIf { it.isNotBlank() }?.run { ShortChannelId(this) }
+                    HopDesc(n1, n2, cid)
+                }
             }
 
             override fun encode(value: List<HopDesc>): String = value.joinToString(";") {

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/cloud/CloudDataTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/cloud/CloudDataTest.kt
@@ -1,0 +1,266 @@
+package fr.acinq.phoenix.db.cloud
+
+import fr.acinq.bitcoin.*
+import fr.acinq.lightning.*
+import fr.acinq.lightning.Lightning.randomBytes32
+import fr.acinq.lightning.Lightning.randomKey
+import fr.acinq.lightning.db.ChannelClosingType
+import fr.acinq.lightning.db.HopDesc
+import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.db.OutgoingPayment
+import fr.acinq.lightning.payment.FinalFailure
+import fr.acinq.lightning.payment.PaymentRequest
+import fr.acinq.lightning.utils.UUID
+import fr.acinq.lightning.utils.msat
+import fr.acinq.lightning.utils.sat
+import fr.acinq.lightning.utils.toByteVector32
+import fr.acinq.phoenix.runTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class CloudDataTest {
+
+    private val preimage = randomBytes32()
+    private val paymentHash = Crypto.sha256(preimage).toByteVector32()
+
+    private val bitcoinAddress = "1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb"
+
+    private val channelId = randomBytes32()
+
+    private val publicKey = randomKey().publicKey()
+    private val uuid = UUID.randomUUID()
+
+    fun testRoundtrip(incomingPayment: IncomingPayment) {
+        // serialize payment into blob
+        val blob = CloudData(incomingPayment, version = 0).cborSerialize()
+
+        // attempt to deserialize & extract payment
+        val data = CloudData.cborDeserialize(blob)
+        assertNotNull(data)
+        val decoded = data.incoming?.unwrap()
+        assertNotNull(decoded)
+
+        // test equality (no loss of information)
+        assertTrue { incomingPayment == decoded }
+    }
+
+    fun testRoundtrip(outgoingPayment: OutgoingPayment) {
+        // serialize payment into blob
+        val blob = CloudData(outgoingPayment, version = 0).cborSerialize()
+
+        // attempt to deserialize & extract payment
+        val data = CloudData.cborDeserialize(blob)
+        assertNotNull(data)
+        val decoded = data.outgoing?.unwrap()
+        assertNotNull(decoded)
+
+        // test equality (no loss of information)
+        assertTrue { outgoingPayment == decoded }
+    }
+
+    @Test
+    fun incoming__invoice() = runTest {
+        val invoice = createInvoice(preimage, 250_000.msat)
+        testRoundtrip(IncomingPayment(
+            preimage = preimage,
+            origin = IncomingPayment.Origin.Invoice(invoice),
+            received = null
+        ))
+    }
+
+    @Test
+    fun incoming__keySend() = runTest {
+        testRoundtrip(IncomingPayment(
+            preimage = preimage,
+            origin = IncomingPayment.Origin.KeySend,
+            received = null
+        ))
+    }
+
+    @Test
+    fun incoming__swapIn() = runTest {
+        testRoundtrip(IncomingPayment(
+            preimage = preimage,
+            origin = IncomingPayment.Origin.SwapIn(bitcoinAddress),
+            received = null
+        ))
+    }
+
+    @Test
+    fun incoming__receivedWith_lightning() = runTest {
+        val invoice = createInvoice(preimage, 250_000.msat)
+        val receivedWith1 = IncomingPayment.ReceivedWith.LightningPayment(
+            amount = 100_000.msat, channelId = channelId, htlcId = 1L
+        )
+        val receivedWith2 = IncomingPayment.ReceivedWith.LightningPayment(
+            amount = 150_000.msat, channelId = channelId, htlcId = 1L
+        )
+        testRoundtrip(IncomingPayment(
+            preimage = preimage,
+            origin = IncomingPayment.Origin.Invoice(invoice),
+            received = IncomingPayment.Received(setOf(receivedWith1, receivedWith2))
+        ))
+    }
+
+    @Test
+    fun incoming__receivedWith_newChannel() = runTest {
+        val invoice = createInvoice(preimage, 10_000_000.msat)
+        val receivedWith = IncomingPayment.ReceivedWith.NewChannel(
+            amount = 7_000_000.msat, fees = 3_000_000.msat, channelId = channelId
+        )
+        testRoundtrip(IncomingPayment(
+            preimage = preimage,
+            origin = IncomingPayment.Origin.Invoice(invoice),
+            received = IncomingPayment.Received(setOf(receivedWith))
+        ))
+    }
+
+    @Test
+    fun outgoing__normal() = runTest {
+        val invoice = createInvoice(preimage, 1_000_000.msat)
+        testRoundtrip(OutgoingPayment(
+            id = uuid,
+            amount = 1_000_000.msat,
+            recipient = publicKey,
+            details = OutgoingPayment.Details.Normal(invoice)
+        ))
+    }
+
+    @Test
+    fun outgoing__keySend() = runTest {
+        testRoundtrip(OutgoingPayment(
+            id = uuid,
+            amount = 1_000_000.msat,
+            recipient = publicKey,
+            details = OutgoingPayment.Details.KeySend(preimage)
+        ))
+    }
+
+    @Test
+    fun outgoing__swapOut() = runTest {
+        testRoundtrip(OutgoingPayment(
+            id = uuid,
+            amount = 1_000_000.msat,
+            recipient = publicKey,
+            details = OutgoingPayment.Details.SwapOut(bitcoinAddress, paymentHash)
+        ))
+    }
+
+    @Test
+    fun outgoing__channelClosing() = runTest {
+        testRoundtrip(OutgoingPayment(
+            id = uuid,
+            amount = 1_000_000.msat,
+            recipient = publicKey,
+            details = OutgoingPayment.Details.ChannelClosing(
+                channelId = channelId,
+                closingAddress = bitcoinAddress,
+                isSentToDefaultAddress = true
+            )
+        ))
+    }
+
+    @Test
+    fun outgoing__failed() = runTest {
+        val recipientAmount = 500_000.msat
+        val invoice = createInvoice(preimage, recipientAmount)
+        val (a, b) = listOf(randomKey().publicKey(), randomKey().publicKey())
+        val part = OutgoingPayment.Part(
+            id = UUID.randomUUID(),
+            amount = 500_005.msat,
+            route = listOf(HopDesc(a, b)),
+            status = OutgoingPayment.Part.Status.Failed(
+                remoteFailureCode = 418,
+                details = "I'm a teapot"
+            )
+        )
+        val outgoingPayment = OutgoingPayment(
+            id = uuid,
+            recipientAmount = recipientAmount,
+            recipient = publicKey,
+            details = OutgoingPayment.Details.Normal(invoice),
+            parts = listOf(part),
+            status = OutgoingPayment.Status.Completed.Failed(FinalFailure.UnknownError)
+        )
+
+        // serialize payment into blob
+        val blob = CloudData(outgoingPayment, version = 0).cborSerialize()
+
+        // attempt to deserialize & extract payment
+        val data = CloudData.cborDeserialize(blob)
+        assertNotNull(data)
+        val decoded = data.outgoing?.unwrap()
+        assertNotNull(decoded)
+
+        // test equality (no loss of information)
+        assertTrue { outgoingPayment == decoded }
+    }
+
+    @Test
+    fun outgoing__succeeded_onChain() = runTest {
+        val recipientAmount = 500_000.msat
+        val invoice = createInvoice(preimage, recipientAmount)
+        val (a, b) = listOf(randomKey().publicKey(), randomKey().publicKey())
+        val part1 = OutgoingPayment.Part(
+            id = UUID.randomUUID(),
+            amount = 250_005.msat,
+            route = listOf(HopDesc(a, b)),
+            status = OutgoingPayment.Part.Status.Succeeded(preimage)
+        )
+        val part2 = OutgoingPayment.Part(
+            id = UUID.randomUUID(),
+            amount = 250_005.msat,
+            route = listOf(HopDesc(a, b)),
+            status = OutgoingPayment.Part.Status.Succeeded(preimage)
+        )
+        testRoundtrip(OutgoingPayment(
+            id = uuid,
+            recipientAmount = recipientAmount,
+            recipient = publicKey,
+            details = OutgoingPayment.Details.Normal(invoice),
+            parts = listOf(part1, part2),
+            status = OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage)
+        ))
+    }
+
+    @Test
+    fun outgoing__succeeded_offChain() = runTest {
+        testRoundtrip(OutgoingPayment(
+            id = uuid,
+            recipientAmount = 1_000_000.msat,
+            recipient = publicKey,
+            details = OutgoingPayment.Details.ChannelClosing(
+                channelId = channelId,
+                closingAddress = bitcoinAddress,
+                isSentToDefaultAddress = true
+            ),
+            parts = listOf(),
+            status = OutgoingPayment.Status.Completed.Succeeded.OnChain(
+                txids = listOf(randomBytes32()),
+                claimed = 1_000.sat,
+                closingType = ChannelClosingType.Mutual
+            )
+        ))
+    }
+
+    companion object {
+        private val defaultFeatures = Features(
+            Feature.VariableLengthOnion to FeatureSupport.Optional,
+            Feature.PaymentSecret to FeatureSupport.Optional,
+            Feature.BasicMultiPartPayment to FeatureSupport.Optional
+        )
+
+        private fun createInvoice(preimage: ByteVector32, amount: MilliSatoshi): PaymentRequest {
+            return PaymentRequest.create(
+                chainHash = Block.LivenetGenesisBlock.hash,
+                amount = amount,
+                paymentHash = Crypto.sha256(preimage).toByteVector32(),
+                privateKey = randomKey(),
+                description = "invoice",
+                minFinalCltvExpiryDelta = CltvExpiryDelta(16),
+                features = defaultFeatures
+            )
+        }
+    }
+}


### PR DESCRIPTION
This PR adds serialization & deserialization for `IncomingPayment` & `OutgoingPayment`. The aim is to provide **cross-platform serialization support for cloud backup**. It re-uses the existing logic from the database layer, and provides a simple wrapper for the remaining parts.

Note that there are a few differences between the cloud vs the local database. With the most significant difference being the cost of space.

For the local system, space is cheap, and the disk is fast. But for the cloud, space is really expensive. On iOS, the user only has 5GB of cloud storage. But that's NOT 5GB per app. That 5GB is shared by every app on their phone. Which means we're expected to be a good steward of their cloud space.

So I spent some time optimizing the size of the serialized blobs. And what I discovered was rather interesting:

First I discovered that Kotlin encodes a ByteArray within JSON like this:

```json
{
  "byteArray": [123,34,112,97,121,109,101,110,116]
}
```

Lol 😂 That is horrible !

So then I added support for Base64, via a new `ByteVectorJsonSerializer`, which reduced the size considerably.

And then I discovered Kotlin's CBOR encoding, which is the proper solution for encoding ByteArray's. And we were able to cut the size dramatically.

Unit tests have been added as well.

#### Side Note:

I suspect that we can use the techniques learned here (base64 and/or CBOR), to reduce the size of our local-database blobs. Which would, in turn, reduce the size of our cloud blobs too! However, I haven't had the time to investigate this yet.