### PR TITLE
Minor code cleanup

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
@@ -1,5 +1,6 @@
 package fr.acinq.phoenix
 
+import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.MnemonicCode
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
@@ -67,7 +68,7 @@ class PhoenixBusiness(
 
     var appConnectionsDaemon: AppConnectionsDaemon? = null
 
-    internal val walletManager by lazy { WalletManager() }
+    internal val walletManager by lazy { WalletManager(chain) }
     internal val appDb by lazy { SqliteAppDb(createAppDbDriver(ctx)) }
 
     val nodeParamsManager by lazy { NodeParamsManager(this) }
@@ -101,13 +102,13 @@ class PhoenixBusiness(
         if (walletManager.wallet.value == null) {
             walletManager.loadWallet(seed)
             return walletManager.wallet.value?.let {
-                it.cloudKeyAndEncryptedNodeId(chain)
+                it.cloudKeyAndEncryptedNodeId()
             }
         }
         return null
     }
 
-    fun getXpub(): Pair<String, String>? = walletManager.wallet.value?.xpub(chain.isMainnet())
+    fun getXpub(): Pair<String, String>? = walletManager.wallet.value?.xpub()
 
     fun peerState() = peerManager.peerState
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/CloseChannelsConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/CloseChannelsConfigurationController.kt
@@ -100,10 +100,7 @@ class AppCloseChannelsConfigurationController(
                         else -> "m/84'/1'/0'/0/0"
                     }
                     val wallet = walletManager.wallet.value!!
-                    val address = wallet.onchainAddress(
-                        path = path,
-                        isMainnet = chain.isMainnet()
-                    )
+                    val address = wallet.onchainAddress(path)
 
                     model(CloseChannelsConfiguration.Model.Ready(closableChannelsList, address))
                 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
@@ -8,12 +8,14 @@ import kotlinx.serialization.Serializable
 import kotlin.math.roundToLong
 
 
-sealed class Chain(val name: String, val chainHash: ByteVector32) {
-    object Regtest: Chain("Regtest", Block.LivenetGenesisBlock.hash)
-    object Testnet: Chain("Testnet", Block.LivenetGenesisBlock.hash)
-    object Mainnet: Chain("Mainnet", Block.LivenetGenesisBlock.hash)
+sealed class Chain(val name: String, val block: Block) {
+    object Regtest: Chain("Regtest", Block.LivenetGenesisBlock)
+    object Testnet: Chain("Testnet", Block.LivenetGenesisBlock)
+    object Mainnet: Chain("Mainnet", Block.LivenetGenesisBlock)
     fun isMainnet(): Boolean = this is Mainnet
     fun isTestnet(): Boolean = this is Testnet
+
+    val chainHash by lazy { block.hash }
 }
 
 interface CurrencyUnit

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/Wallet.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/Wallet.kt
@@ -3,32 +3,32 @@ package fr.acinq.phoenix.data
 import fr.acinq.bitcoin.*
 
 
-data class Wallet(val seed: ByteArray) {
+data class Wallet(val seed: ByteVector64, val chain: Chain) {
 
-    init {
-        require(seed.size == 64) { "invalid seed.size" }
-    }
+    constructor(seed: ByteArray, chain: Chain): this(ByteVector64(seed), chain)
 
     private val master by lazy { DeterministicWallet.generate(seed) }
 
-    fun masterPublicKey(path: String, isMainnet: Boolean): String {
+    fun masterPublicKey(path: String): String {
         val publicKey =
             DeterministicWallet.publicKey(
                 DeterministicWallet.derivePrivateKey(master, path)
             )
         return DeterministicWallet.encode(
             input = publicKey,
-            prefix = if (isMainnet) DeterministicWallet.zpub else DeterministicWallet.vpub
+            prefix = if (chain.isMainnet()) DeterministicWallet.zpub else DeterministicWallet.vpub
         )
     }
 
     /** Get the wallet (xpub, path) */
-    fun xpub(isMainnet: Boolean): Pair<String, String> {
+    fun xpub(): Pair<String, String> {
+        val isMainnet = chain.isMainnet()
         val masterPubkeyPath = if (isMainnet) "m/84'/0'/0'" else "m/84'/1'/0'"
-        return masterPublicKey(masterPubkeyPath, isMainnet) to masterPubkeyPath
+        return masterPublicKey(masterPubkeyPath) to masterPubkeyPath
     }
 
-    fun onchainAddress(path: String, isMainnet: Boolean): String {
+    fun onchainAddress(path: String): String {
+        val isMainnet = chain.isMainnet()
         val chainHash = if (isMainnet) Block.LivenetGenesisBlock.hash else Block.TestnetGenesisBlock.hash
         val publicKey = DeterministicWallet.derivePrivateKey(master, path).publicKey
         return Bitcoin.computeBIP84Address(publicKey, chainHash)
@@ -41,35 +41,14 @@ data class Wallet(val seed: ByteArray) {
     // But we also don't want to expose the nodeId.
     // So we deterministically derive both values from the seed.
     //
-    fun cloudKeyAndEncryptedNodeId(chain: Chain): Pair<ByteVector32, String> {
-        val isTestnet = when (chain) {
-            is Chain.Testnet, is Chain.Regtest -> true
-            else -> false
-        }
-        val path = if (isTestnet) "m/51'/1'/0'/0" else "m/51'/0'/0'/0"
-
+    fun cloudKeyAndEncryptedNodeId(): Pair<ByteVector32, String> {
+        val path = if (chain.isMainnet()) "m/51'/0'/0'/0" else "m/51'/1'/0'/0"
         val extPrivKey = DeterministicWallet.derivePrivateKey(master, path)
 
         val cloudKey = extPrivKey.privateKey.value
         val hash = Crypto.hash160(cloudKey).byteVector().toHex()
 
         return Pair(cloudKey, hash)
-    }
-
-    // Recommended when data class props contain arrays
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as Wallet
-
-        if (!seed.contentEquals(other.seed)) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return seed.contentHashCode()
     }
 
     override fun toString(): String = "Wallet"

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NodeParamsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NodeParamsManager.kt
@@ -58,13 +58,8 @@ class NodeParamsManager(
             walletManager.wallet.collect {
                 if (it == null) return@collect
                 log.info { "wallet available: building nodeParams..." }
-                val genesisBlock = when (chain) {
-                    Chain.Mainnet -> Block.LivenetGenesisBlock
-                    Chain.Testnet -> Block.TestnetGenesisBlock
-                    Chain.Regtest -> Block.RegtestGenesisBlock
-                }
 
-                val keyManager = LocalKeyManager(it.seed.toByteVector(), genesisBlock.hash)
+                val keyManager = LocalKeyManager(seed = it.seed, chainHash = chain.chainHash)
                 log.info { "nodeid=${keyManager.nodeId}" }
 
                 val nodeParams = NodeParams(
@@ -109,7 +104,7 @@ class NodeParamsManager(
                     autoReconnect = false,
                     initialRandomReconnectDelaySeconds = 5,
                     maxReconnectIntervalSeconds = 3600,
-                    chainHash = genesisBlock.hash,
+                    chainHash = chain.chainHash,
                     channelFlags = 1,
                     paymentRequestExpirySeconds = 3600,
                     multiPartPaymentExpirySeconds = 60,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/WalletManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/WalletManager.kt
@@ -1,5 +1,7 @@
 package fr.acinq.phoenix.managers
 
+import fr.acinq.bitcoin.ByteVector
+import fr.acinq.phoenix.data.Chain
 import fr.acinq.phoenix.data.Wallet
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -8,12 +10,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class WalletManager : CoroutineScope by MainScope() {
+class WalletManager(
+    private val chain: Chain
+) : CoroutineScope by MainScope() {
+
     private val _wallet = MutableStateFlow<Wallet?>(null)
     val wallet: StateFlow<Wallet?> = _wallet
 
     fun loadWallet(seed: ByteArray) {
-        val newWallet = Wallet(seed = seed)
+        val newWallet = Wallet(seed, chain)
         _wallet.value = newWallet
     }
 }

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/data/WalletTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/data/WalletTest.kt
@@ -24,21 +24,22 @@ class WalletTest {
     private val mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
     private val seed = MnemonicCode.toSeed(mnemonics, passphrase = "")
 
-    private val wallet = Wallet(seed)
+    private val mainnetWallet = Wallet(seed, Chain.Mainnet)
+    private val testnetWallet = Wallet(seed, Chain.Testnet)
 
     @Test
     fun masterPublicKey() {
         // Mainnet
-        assertEquals(wallet.masterPublicKey("m/84'/0'/0'",true), "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs")
+        assertEquals(mainnetWallet.masterPublicKey("m/84'/0'/0'"), "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs")
         // Testnet
-        assertEquals(wallet.masterPublicKey("m/84'/1'/0'",false), "vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc")
+        assertEquals(testnetWallet.masterPublicKey("m/84'/1'/0'"), "vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc")
     }
 
     @Test
     fun onchainAddress() {
         // Mainnet
-        assertEquals(wallet.onchainAddress("m/84'/0'/0'/0/0",true), "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu")
+        assertEquals(mainnetWallet.onchainAddress("m/84'/0'/0'/0/0"), "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu")
         // Testnet
-        assertEquals(wallet.onchainAddress("m/84'/1'/0'/0/0", false), "tb1q6rz28mcfaxtmd6v789l9rrlrusdprr9pqcpvkl")
+        assertEquals(testnetWallet.onchainAddress("m/84'/1'/0'/0/0"), "tb1q6rz28mcfaxtmd6v789l9rrlrusdprr9pqcpvkl")
     }
 }


### PR DESCRIPTION
Previously, `Wallet.kt` only contained the seed. Which meant that nearly every function required information about the chain:

```kotlin
data class Wallet(val seed: ByteArray) {
  
  fun masterPublicKey(path: String, isMainnet: Boolean): String {}
  fun xpub(isMainnet: Boolean): Pair<String, String> {}
}
```

Given that the `chain` is a constant defined in PhoenixBusiness, it seems cleaner if Wallet accepts the `chain` as a constructor parameter:

```kotlin
data class Wallet(val seed: ByteVector, val chain: Chain) {
  
  fun masterPublicKey(path: String): String {}
  fun xpub(): Pair<String, String> {}
}
```

Also, if we switch from `seed: ByteArray` to `seed: ByteVector`, then Kotlin will generate the `equals` & `hashCode` functions for us without complaining.

And, finally, we improve `Chain` by making the `Block` accessible:

```kotlin
// Before:
sealed class Chain(val name: String, val chainHash: ByteVector32) {
  object Mainnet: Chain("Mainnet", Block.LivenetGenesisBlock.hash)
  // ...
}

// After:
sealed class Chain(val name: String, val block: Block) {
  object Mainnet: Chain("Mainnet", Block.LivenetGenesisBlock)
  // ...

  val chainHash by lazy { block.hash }
}
```



